### PR TITLE
Add missing commas to BooleanSerializer.true/false

### DIFF
--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -50,7 +50,7 @@ class BooleanSerializer(BaseSerializer):
         "TRUE",
         "1",
         "YES",
-        "Yes"
+        "Yes",
         "yes",
     )
 
@@ -60,8 +60,8 @@ class BooleanSerializer(BaseSerializer):
         "FALSE",
         "0",
         "No",
-        "no"
-        "NO"
+        "no",
+        "NO",
     )
 
 


### PR DESCRIPTION
Just a minor edit, I stumbled across this the other day (I was writing a data migration to "migrate" an preference definition change, but that's mostly unrelated). I actually haven't had any problems with it because (at least for me) it always serializes to "True" and "False", which are valid items in the list as-is, so it works fine. But I assume there were meant to be commas on each line?

(duplicate of #54, this time to the develop branch)