### PR TITLE
Fixed #49 and fixed #71 by passing section objects in templates, and not only the sections identifiers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+Current
+********
+
+* Fixed #49 and #71 by passing full section objects in templates (and not just the section identifiers). This means it's easier to write template that use sections, for example if you want have i18n in your project and want to display the translated section's name. URL reversing for sections is also more reliable in templates. If you subclassed `PreferenceRegistry`  to implement your own preference class and use the built-in templates, you need to add a ``section_url_namespace`` attribute to your registry class to benefit from the new URL reversing.
+
 [Major release] 1.0 (21-02-2017)
 ***********************************
 

--- a/dynamic_preferences/registries.py
+++ b/dynamic_preferences/registries.py
@@ -91,6 +91,13 @@ class PreferenceRegistry(persisting_theory.Registry):
     name = "preferences_registry"
     preference_model = None
 
+    #: used to reverse urls for sections in form views/templates
+    section_url_namespace = None
+
+    def __init__(self, *args, **kwargs):
+        super(PreferenceRegistry, self).__init__(*args, **kwargs)
+        self.section_objects = collections.OrderedDict()
+
     def register(self, preference_class):
         """
         Store the given preference class in the registry.
@@ -98,6 +105,8 @@ class PreferenceRegistry(persisting_theory.Registry):
         :param preference_class: a :py:class:`prefs.Preference` subclass
         """
         preference = preference_class(registry=self)
+        self.section_objects[preference.section.name] = preference.section
+
         try:
             self[preference.section.name][preference.name] = preference
 
@@ -203,6 +212,8 @@ class PerInstancePreferenceRegistry(PreferenceRegistry):
 
 
 class GlobalPreferenceRegistry(PreferenceRegistry):
+    section_url_namespace = 'dynamic_preferences.global.section'
+
     def populate(self, **kwargs):
         return self.models(**kwargs)
 

--- a/dynamic_preferences/templates/dynamic_preferences/base.html
+++ b/dynamic_preferences/templates/dynamic_preferences/base.html
@@ -5,7 +5,8 @@
 </head>
 <body>
     <div class="sidebar">
-        {% include "dynamic_preferences/sections.html" %}
+        {# we continue to pass the sections key in case someone subclassed the template and use these #}
+        {% include "dynamic_preferences/sections.html" with registry=registry sections=registry.sections %}
     </div>
     <div class="main_content">
         {% block content %}{% endblock %}

--- a/dynamic_preferences/templates/dynamic_preferences/form.html
+++ b/dynamic_preferences/templates/dynamic_preferences/form.html
@@ -2,7 +2,8 @@
 {% load i18n %}
 {% block content %}
 
-    {% include "dynamic_preferences/sections.html" with sections=registry.sections %}
+    {# we continue to pass the sections key in case someone subclassed the template and use these #}
+    {% include "dynamic_preferences/sections.html" with registry=registry sections=registry.sections %}
 
     <form action="" enctype="multipart/form-data" method="post">
         {% csrf_token %}

--- a/dynamic_preferences/templates/dynamic_preferences/sections.html
+++ b/dynamic_preferences/templates/dynamic_preferences/sections.html
@@ -1,5 +1,8 @@
 <ul class="sections">
-    {% for section in sections %}
-        <li><a href="./{{ section }}">{{ section }}</a></li>
+    {% for section in registry.section_objects.values %}
+        <li>
+            <a href="{% if registry.section_url_namespace %}{% url registry.section_url_namespace section=section.name %}{% else %}./{{ section.name }}{% endif %}"
+            >{{ section.verbose_name }}</a>
+        </li>
     {% endfor %}
 </ul>

--- a/dynamic_preferences/users/registries.py
+++ b/dynamic_preferences/users/registries.py
@@ -2,7 +2,7 @@ from ..registries import PerInstancePreferenceRegistry
 
 
 class UserPreferenceRegistry(PerInstancePreferenceRegistry):
-    pass
+    section_url_namespace = 'dynamic_preferences.user.section'
 
 
 user_preferences_registry = UserPreferenceRegistry()

--- a/dynamic_preferences/views.py
+++ b/dynamic_preferences/views.py
@@ -1,4 +1,5 @@
 from django.views.generic import TemplateView, FormView
+from django.http import Http404
 from .forms import preference_form_builder
 
 
@@ -9,28 +10,43 @@ class RegularTemplateView(TemplateView):
 
 
 class PreferenceFormView(FormView):
-    """Display a form for updating preferences of the given section provided via URL arg.
-    If no section is provided, will display a form for all fields of a given registry.
+    """
+    Display a form for updating preferences of the given
+    section provided via URL arg.
+    If no section is provided, will display a form for all
+    fields of a given registry.
     """
 
     #: the registry for preference lookups
     registry = None
 
-    #: will be used by :py:func:`forms.preference_form_builder` to create the form
+    #: will be used by :py:func:`forms.preference_form_builder`
+    # to create the form
     form_class = None
-
     template_name = "dynamic_preferences/form.html"
 
+    def dispatch(self, request, *args, **kwargs):
+        self.section_name = kwargs.get('section', None)
+        if self.section_name:
+            try:
+                self.section = self.registry.section_objects[self.section_name]
+            except KeyError:
+                raise Http404
+        else:
+            self.section = None
+        return super(PreferenceFormView, self).dispatch(
+            request, *args, **kwargs)
+
     def get_form_class(self, *args, **kwargs):
-        section = self.kwargs.get('section', None)
-        form_class = preference_form_builder(self.form_class, section=section)
+        form_class = preference_form_builder(
+            self.form_class, section=self.section_name)
         return form_class
 
     def get_context_data(self, *args, **kwargs):
-
-        context = super(PreferenceFormView, self).get_context_data(*args, **kwargs)
-
+        context = super(PreferenceFormView, self).get_context_data(
+            *args, **kwargs)
         context['registry'] = self.registry
+        context['section'] = self.section
 
         return context
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,6 @@
 
 DEBUG = True
+TEMPLATE_DEBUG = True
 USE_TZ = True
 DATABASES = {
     "default": {
@@ -45,6 +46,7 @@ if check_django_version("1.8"):
             'DIRS': [],
             'APP_DIRS': True,
             'OPTIONS': {
+                'debug': True,
                 'context_processors': [
                     'django.template.context_processors.request',
                     'dynamic_preferences.processors.global_preferences',

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -7,5 +7,5 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^', include("dynamic_preferences.urls")),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^test/template$',views.RegularTemplateView.as_view(), name="dynamic_preferences.test.templateview"),      
+    url(r'^test/template$',views.RegularTemplateView.as_view(), name="dynamic_preferences.test.templateview"),
 ]


### PR DESCRIPTION
@JanMalte and @leetucker this should fix your issues, can you test this in your projects and tell me if everything is okay?

Basically, the template context for the form template now includes:

1. The preference registry, which you can use to retrieve sections by looping on the `section_objects` attribute: `{% for section in registry.section_objects %}{{ section.verbose_name }}{% endfor %}
2. The current section object (if any) is accessible under the `section` context key. If no section is selected, this value will be at `None`: `Current section is {{ section.verbose_name }}`

Hopefully, this should make it easier to write templates that involves sections and i18n.