### PR TITLE
Feature/rest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - TOX_ENV=py35-django-110
   - TOX_ENV=py34-django-110
   - TOX_ENV=py27-django-110
-  - TOX_ENV=py36-django-111
+  # - TOX_ENV=py36-django-111
   - TOX_ENV=py35-django-111
   - TOX_ENV=py34-django-111
   - TOX_ENV=py27-django-111

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,42 @@
-# Config file for automatic testing at travis-ci.org
+language: python
 cache: pip
 sudo: false
 
-language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
 
 env:
-  - DJANGO="Django>=1.7,<1.8"
-  - DJANGO="Django>=1.8,<1.9"
-  - DJANGO="Django>=1.9,<1.10"
-  - DJANGO="Django>=1.10,<1.11"
-  - DJANGO="Django>=1.11,<2"
-  - DJANGO="https://github.com/django/django/tarball/master"
-
+  - TOX_ENV=py35-django-18
+  - TOX_ENV=py34-django-18
+  - TOX_ENV=py33-django-18
+  - TOX_ENV=py27-django-18
+  - TOX_ENV=py35-django-19
+  - TOX_ENV=py34-django-19
+  - TOX_ENV=py27-django-19
+  - TOX_ENV=py35-django-110
+  - TOX_ENV=py34-django-110
+  - TOX_ENV=py27-django-110
+  - TOX_ENV=py36-django-111
+  - TOX_ENV=py35-django-111
+  - TOX_ENV=py34-django-111
+  - TOX_ENV=py27-django-111
+  # - TOX_ENV=py36-django-master
+  - TOX_ENV=py35-django-master
 
 matrix:
-  exclude:
-    - python: "3.5"
-      env: DJANGO="Django>=1.7,<1.8"
+  fast_finish: true
   allow_failures:
-    - env: DJANGO="https://github.com/django/django/tarball/master"
+    - env: TOX_ENV=py35-django-master
+    # - env: TOX_ENV=py36-django-master
 
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+# install: pip install pytest-django
 
-before_install:
-    - pip install codecov
+# command to run tests using coverage, e.g. python setup.py test
+script: tox -e $TOX_ENV
 
 install:
-    - pip install $DJANGO && pip install -r requirements-test.txt
-
-script:
-    - coverage run --source=dynamic_preferences pytest
+  - pip install tox codecov
 
 after_success:
-    - codecov
+  - codecov -e TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django>=1.11,<2"
   - DJANGO="https://github.com/django/django/tarball/master"
 
 
@@ -31,7 +32,7 @@ install:
     - pip install $DJANGO && pip install -r requirements-test.txt
 
 script:
-    - coverage run --source=dynamic_preferences runtests.py
+    - coverage run --source=dynamic_preferences pytest
 
 after_success:
     - codecov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+Current
+*******************
+
+- important performance improvements (less database and cache queries)
+- rest api (wip)
+
+
 1.1.1 (11-05-2017)
 *******************
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Features
 * Bundled with global and per-user preferences
 * Can be extended to other models if need (e.g. per-site preferences)
 * Integrates with django caching mechanisms to improve performance
+* Django REST Framework integration
 
 If you're still interested, head over :doc:`installation`.
 
@@ -39,8 +40,9 @@ Contents:
 
    installation
    quickstart
-   lifecycle
    bind_preferences_to_models
+   rest_api
+   lifecycle
    upgrade
    contributing
    authors

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -128,6 +128,32 @@ A few other methods are available on managers to retrieve preferences:
    The preference section name (if any) is removed from the identifier
 - `manager.get_by_name(name)`: returns a single preference value using only the preference name
 
+Additional validation
+*********************
+
+In some situations, you'll want to enforce custom rules for your preferences
+values, and raise validation errors when those rules are not matched.
+
+You can implement that behaviour by declaring a ``validate`` method on your preference
+class, as follows:
+
+.. code-block:: python
+
+    from django.forms import ValidationError
+
+    # We start with a global preference
+    @global_preferences_registry.register
+    class MeaningOfLife(IntegerPreference):
+        name = 'meaning_of_life'
+        default = 42
+
+        def validate(self, value):
+            # ensure the meaning of life is always 42
+            if value != 42:
+                raise ValidationError('42 only')
+
+Internally, the validate method is pass as `a validator <https://docs.djangoproject.com/en/1.11/ref/validators/>`_ to the underlying form field.
+
 About serialization
 *******************
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -1,0 +1,106 @@
+REST API
+========
+
+Dynamic preferences provides an optionnal integration with Django REST Framework:
+
+- Serializers you can use for global and user preferences (or to extend for your own preferences)
+- Viewsets you can use for global and user preferences (or to extend for your own preferences)
+
+Getting started
+---------------
+
+The easiest way to offer API endpoints to manage preferences in your project is to use
+bundled viewsets in your ``urs.py``:
+
+.. code-block:: python
+
+    from django.conf.urls import include, url
+    from rest_framework import routers
+
+    from dynamic_preferences.api.viewsets import GlobalPreferencesViewSet
+    from dynamic_preferences.users.viewsets import UserPreferencesViewSet
+
+
+    router = routers.SimpleRouter()
+    router.register(r'global', GlobalPreferencesViewSet, base_name='global')
+
+    # Uncomment this one if you use user preferences
+    # router.register(r'user', UserPreferencesViewSet, base_name='user')
+
+    api_patterns = [
+        url(r'^preferences/', include(router.urls, namespace='preferences'))
+
+    ]
+    urlpatterns = [
+        # your other urls here
+        url(r'^api/', include(api_patterns, namespace='api'))
+    ]
+
+
+Endpoints
+---------
+
+For each preference viewset, the following endpoints are available:
+
+Example reverse and urls are given according to the previous snippet. You'll
+have to adapt them to your own URL namespaces and structure.
+
+List
+^^^^^^^
+
+- Methods: GET
+- Returns a list of preferences
+- Reverse example: ``reverse('api:preferences:global-list')``
+- URL example: ``/api/preferences/global/``
+
+Detail
+^^^^^^^
+
+- Methods: GET, PATCH
+- Get or update a single preference
+- Reverse example: ``reverse('api:preferences:global-detail', kwargs={'pk': 'section__name'})``
+- URL example: ``/api/preferences/global/section__name``
+
+If you call this endpoint via PATCH HTTP method, you can update the preference value.
+The following payload is expected::
+
+
+    {
+        value: 'new_value'
+    }
+
+.. note::
+
+    When updating the preference value, the underlying serializers will call
+    the preference field validators, and the preference ``validate`` method,
+    if any is available.
+
+Bulk
+^^^^^
+
+- Methods: POST
+- Update multiple preferences at once
+- Reverse example: ``reverse('api:preferences:global-bulk')``
+- URL example: ``/api/preferences/global/bulk``
+
+If you call this endpoint via POST HTTP method, you can update the the value
+of multiple preferences at once. Example payload::
+
+    {
+        section1__name1: 'new_value',
+        section2__name2: false,
+    }
+
+This will update the preferences whose identifiers match ``section1__name1``
+and ``section2__name2`` with the corresponding values.
+
+.. note::
+
+    Validation will be called for each preferences, ans save will only occur
+    if no error happens.
+
+A note about permissions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``GlobalPreferencesViewSet`` will check the user has the ``dynamic_preferences.change_globalpreferencemodel`` permission
+- ``UserPreferencesViewSet`` will check the user is logged in and only allow him to edit his own preferences.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,0 @@
-========
-Usage
-========
-
-To use django-dynamic-preferences in a project::
-
-    import django-dynamic-preferences

--- a/dynamic_preferences/api/serializers.py
+++ b/dynamic_preferences/api/serializers.py
@@ -1,0 +1,62 @@
+from rest_framework import serializers
+from dynamic_preferences.models import GlobalPreferenceModel
+
+
+class PreferenceValueField(serializers.Field):
+    def get_attribute(self, o):
+        return o
+
+    def to_representation(self, o):
+        return o.preference.api_repr(
+            o.value
+        )
+
+    def to_internal_value(self, data):
+        return data
+
+
+class PreferenceSerializer(serializers.Serializer):
+
+    section = serializers.CharField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    default = serializers.SerializerMethodField()
+    value = PreferenceValueField()
+    verbose_name = serializers.SerializerMethodField()
+    help_text = serializers.SerializerMethodField()
+
+    class Meta:
+        fields = [
+            'default',
+            'value',
+            'verbose_name',
+            'help_text',
+        ]
+
+    def get_default(self, o):
+        return o.preference.api_repr(
+            o.preference.get('default')
+        )
+
+    def get_verbose_name(self, o):
+        return o.preference.get('verbose_name')
+
+    def get_help_text(self, o):
+        return o.preference.get('help_text')
+
+    def validate_value(self, value):
+        """
+        We call validation from the underlying form field
+        """
+        field = self.instance.preference.setup_field()
+        field.validate(value)
+        field.run_validators(value)
+        return value
+
+    def update(self, instance, validated_data):
+        instance.value = validated_data['value']
+        instance.save()
+        return instance
+
+
+class GlobalPreferenceSerializer(PreferenceSerializer):
+    pass

--- a/dynamic_preferences/api/serializers.py
+++ b/dynamic_preferences/api/serializers.py
@@ -19,10 +19,12 @@ class PreferenceSerializer(serializers.Serializer):
 
     section = serializers.CharField(read_only=True)
     name = serializers.CharField(read_only=True)
+    identifier = serializers.SerializerMethodField()
     default = serializers.SerializerMethodField()
     value = PreferenceValueField()
     verbose_name = serializers.SerializerMethodField()
     help_text = serializers.SerializerMethodField()
+    additional_data = serializers.SerializerMethodField()
 
     class Meta:
         fields = [
@@ -40,8 +42,14 @@ class PreferenceSerializer(serializers.Serializer):
     def get_verbose_name(self, o):
         return o.preference.get('verbose_name')
 
+    def get_identifier(self, o):
+        return o.preference.identifier()
+
     def get_help_text(self, o):
         return o.preference.get('help_text')
+
+    def get_additional_data(self, o):
+        return o.preference.get_api_additional_data()
 
     def validate_value(self, value):
         """

--- a/dynamic_preferences/api/serializers.py
+++ b/dynamic_preferences/api/serializers.py
@@ -25,6 +25,7 @@ class PreferenceSerializer(serializers.Serializer):
     verbose_name = serializers.SerializerMethodField()
     help_text = serializers.SerializerMethodField()
     additional_data = serializers.SerializerMethodField()
+    field = serializers.SerializerMethodField()
 
     class Meta:
         fields = [
@@ -50,6 +51,9 @@ class PreferenceSerializer(serializers.Serializer):
 
     def get_additional_data(self, o):
         return o.preference.get_api_additional_data()
+
+    def get_field(self, o):
+        return o.preference.get_api_field_data()
 
     def validate_value(self, value):
         """

--- a/dynamic_preferences/api/viewsets.py
+++ b/dynamic_preferences/api/viewsets.py
@@ -1,0 +1,169 @@
+from django.db import transaction
+from django.db.models import Q
+
+from rest_framework import mixins
+from rest_framework import viewsets
+from rest_framework import permissions
+from rest_framework.response import Response
+from rest_framework.decorators import list_route
+from rest_framework.generics import get_object_or_404
+
+from dynamic_preferences import models
+from dynamic_preferences import exceptions
+from dynamic_preferences.settings import preferences_settings
+
+from . import serializers
+
+
+class PreferenceViewSet(
+        mixins.UpdateModelMixin,
+        mixins.ListModelMixin,
+        mixins.RetrieveModelMixin,
+        viewsets.GenericViewSet):
+    """
+    - list preferences
+    - detail given preference
+    - batch update preferences
+    - update a single preference
+    """
+
+    def get_queryset(self):
+        """
+        We just ensure preferences are actually populated before fetching
+        from db
+        """
+        self.init_preferences()
+        return super(PreferenceViewSet, self).get_queryset()
+
+    def get_manager(self):
+        return self.queryset.model.registry.manager()
+
+    def init_preferences(self):
+        manager = self.get_manager()
+        manager.all()
+
+    def get_object(self):
+        """
+        Returns the object the view is displaying.
+        You may want to override this if you need to provide non-standard
+        queryset lookups.  Eg if objects are referenced using multiple
+        keyword arguments in the url conf.
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        identifier = self.kwargs[lookup_url_kwarg]
+        section, name = self.get_section_and_name(identifier)
+        filter_kwargs = {'section': section, 'name': name}
+        obj = get_object_or_404(queryset, **filter_kwargs)
+
+        # May raise a permission denied
+        self.check_object_permissions(self.request, obj)
+
+        return obj
+
+    def get_section_and_name(self, identifier):
+        try:
+            section, name = identifier.split(
+                preferences_settings.SECTION_KEY_SEPARATOR)
+        except ValueError:
+            # no section given
+            section, name = None, identifier
+
+        return section, name
+
+    @list_route(methods=['post'])
+    @transaction.atomic
+    def bulk(self, request, *args, **kwargs):
+        """
+        Update multiple preferences at once
+
+        this is a long method because we ensure everything is valid
+        before actually persisting the changes
+        """
+        manager = self.get_manager()
+        errors = {}
+        preferences = []
+        payload = request.data
+
+        # first, we check updated preferences actually exists in the registry
+        try:
+            for identifier, value in payload.items():
+                try:
+                    preferences.append(
+                        self.queryset.model.registry.get(identifier))
+                except exceptions.NotFoundInRegistry:
+                    errors[identifier] = 'invalid preference'
+        except (TypeError, AttributeError):
+            return Reponse('invalid payload', status=400)
+
+        if errors:
+            return Response(errors, status=400)
+
+        # now, we generate an optimized Q objects to retrieve all matching
+        # preferences at once from database
+        queries = [
+            Q(section=p.section.name, name=p.name)
+            for p in preferences
+        ]
+
+        query = queries[0]
+        for q in queries[1:]:
+            query |= q
+        preferences_qs = self.get_queryset().filter(query)
+
+        # next, we generate a serializer for each database preference
+        serializer_objects = []
+        for p in preferences_qs:
+            s = self.get_serializer_class()(
+                p, data={'value': payload[p.preference.identifier()]})
+            serializer_objects.append(s)
+
+        validation_errors = {}
+
+        # we check if any serializer is invalid
+        for s in serializer_objects:
+            if s.is_valid():
+                continue
+            validation_errors[s.instance.preference.identifier()] = s.errors
+
+        if validation_errors:
+            return Response(validation_errors, status=400)
+
+        for s in serializer_objects:
+            s.save()
+
+        return Response(
+            [s.data for s in serializer_objects],
+            status=200,
+        )
+
+
+class GlobalPreferencePermission(permissions.DjangoModelPermissions):
+    perms_map = {
+        'GET': ['%(app_label)s.change_%(model_name)s'],
+        'OPTIONS': ['%(app_label)s.change_%(model_name)s'],
+        'HEAD': ['%(app_label)s.change_%(model_name)s'],
+        'POST': ['%(app_label)s.change_%(model_name)s'],
+        'PUT': ['%(app_label)s.change_%(model_name)s'],
+        'PATCH': ['%(app_label)s.change_%(model_name)s'],
+        'DELETE': ['%(app_label)s.change_%(model_name)s'],
+    }
+
+
+class GlobalPreferencesViewSet(PreferenceViewSet):
+    queryset = models.GlobalPreferenceModel.objects.all()
+    serializer_class = serializers.GlobalPreferenceSerializer
+    permission_classes = [GlobalPreferencePermission]
+
+
+class PerInstancePreferenceViewSet(PreferenceViewSet):
+    def get_manager(self):
+        return self.queryset.model.registry.manager(
+            instance=self.get_related_instance()
+        )
+
+    def get_related_instance(self):
+        """
+        Override this to  the instance binded to the preferences
+        """
+        raise NotImplementedError

--- a/dynamic_preferences/managers.py
+++ b/dynamic_preferences/managers.py
@@ -13,10 +13,14 @@ class PreferencesManager(collections.Mapping):
         self.model = model
 
         self.registry = registry
-        self.queryset = self.model.objects.all()
         self.instance = kwargs.get('instance')
+
+    @property
+    def queryset(self):
+        qs = self.model.objects.all()
         if self.instance:
-            self.queryset = self.queryset.filter(instance=self.instance)
+            qs = qs.filter(instance=self.instance)
+        return qs
 
     @property
     def cache(self):
@@ -61,10 +65,31 @@ class PreferencesManager(collections.Mapping):
             raise CachedValueNotFound
         return self.registry.get(section=section, name=name).serializer.deserialize(cached_value)
 
+    def many_from_cache(self, preferences):
+        """
+        Return cached value for given preferences
+        missing preferences will be skipped
+        """
+        keys = {
+            p: self.get_cache_key(p.section.name, p.name)
+            for p in preferences
+        }
+        cached = self.cache.get_many(list(keys.values()))
+
+        # we have to remap returned value since the underlying cached keys
+        # are not usable for an end user
+        return {
+            p.identifier(): p.serializer.deserialize(cached[k])
+            for p, k in keys.items()
+            if k in cached
+        }
+
     def to_cache(self, pref):
-        """Update/create the cache value for the given preference model instance"""
-        self.cache.set(
-            self.get_cache_key(pref.section, pref.name), pref.raw_value, None)
+        """
+        Update/create the cache value for the given preference model instance
+        """
+        key = self.get_cache_key(pref.section, pref.name)
+        self.cache.set(key, pref.raw_value, None)
 
     def pref_obj(self, section, name):
         return self.registry.get(section=section, name=name)
@@ -123,15 +148,19 @@ class PreferencesManager(collections.Mapping):
         }
         if self.instance:
             kwargs['instance'] = self.instance
-            db_pref = self.model(
-                section=section, name=name, instance=self.instance)
-        else:
-            db_pref = self.model(section=section, name=name)
 
-        db_pref, created = self.model.objects.get_or_create(**kwargs)
-        db_pref.value = value
-        db_pref.save()
+        # this is ajust a shortcut to get the raw, serialized value
+        # so we can pass it to udpate_or_create
+        m = self.model(**kwargs)
+        m.value = value
+        raw_value = m.raw_value
 
+        db_pref, updated = self.model.objects.update_or_create(
+            defaults={
+                'raw_value': raw_value
+            },
+            **kwargs
+        )
         return db_pref
 
     def all(self):
@@ -142,12 +171,21 @@ class PreferencesManager(collections.Mapping):
         if not preferences_settings.ENABLE_CACHE:
             return self.load_from_db()
 
-        try:
-            for preference in self.registry.preferences():
-                a[preference.identifier()] = self.from_cache(
-                    preference.section.name, preference.name)
-        except CachedValueNotFound:
-            return self.load_from_db()
+        # first we hit the cache once for all existing preferences
+        cached = self.many_from_cache(self.registry.preferences())
+        # then we fill those that miss
+        for preference in self.registry.preferences():
+            identifier = preference.identifier()
+            try:
+                a[identifier] = cached[identifier]
+            except KeyError:
+                default = preference.get('default')
+                db_pref = self.create_db_pref(
+                    section=preference.section.name,
+                    name=preference.name,
+                    value=default)
+
+                a[preference.identifier()] = default
 
         return a
 
@@ -160,10 +198,10 @@ class PreferencesManager(collections.Mapping):
                 db_pref = db_prefs[preference.identifier()]
             except KeyError:
                 db_pref = self.create_db_pref(
-                    section=preference.section.name, name=preference.name, value=preference.get('default'))
+                    section=preference.section.name,
+                    name=preference.name,
+                    value=preference.get('default'))
 
-            self.to_cache(db_pref)
-            a[preference.identifier()] = self.from_cache(
-                preference.section.name, preference.name)
+            a[preference.identifier()] = db_pref.value
 
         return a

--- a/dynamic_preferences/models.py
+++ b/dynamic_preferences/models.py
@@ -98,10 +98,6 @@ class PerInstancePreferenceModel(BasePreferenceModel):
     def get_instance_model(cls):
         return cls._meta.get_field('instance').rel.to
 
-    @property
-    def registry(self):
-        return preference_models.get_by_instance(self.instance)
-
 
 global_preferences_registry.preference_model = GlobalPreferenceModel
 

--- a/dynamic_preferences/registries.py
+++ b/dynamic_preferences/registries.py
@@ -36,7 +36,8 @@ class PreferenceModelsRegistry(persisting_theory.Registry):
     def register(self, preference_model, preference_registry):
         self[preference_model] = preference_registry
         preference_registry.preference_model = preference_model
-
+        if not hasattr(preference_model, 'registry'):
+            setattr(preference_model, 'registry', preference_registry)
         self.attach_manager(preference_model, preference_registry)
 
     def attach_manager(self, model, registry):

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -61,6 +61,12 @@ class BasePreferenceType(AbstractPreference):
         """
         return value
 
+    def get_api_additional_data(self):
+        """
+        Additional data to serialize for use on front-end side, for example
+        """
+        return {}
+
     def validate(self, value):
         """
         Used to implement custom cleaning logic for use in forms
@@ -120,6 +126,11 @@ class ChoicePreference(BasePreferenceType):
         field_kwargs = super(ChoicePreference, self).get_field_kwargs()
         field_kwargs['choices'] = self.choices or self.field_attribute['initial']
         return field_kwargs
+
+    def get_api_additional_data(self):
+        d = super(ChoicePreference, self).get_api_additional_data()
+        d['choices'] = self.get('choices')
+        return d
 
 
 def create_deletion_handler(preference):

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -67,6 +67,29 @@ class BasePreferenceType(AbstractPreference):
         """
         return {}
 
+    def get_api_field_data(self):
+        """
+        Field data to serialize for use on front-end side, for example
+        will include choices available for a choice field
+        """
+        field = self.setup_field()
+        print(dir(field.widget))
+        d = {
+            'class': field.__class__.__name__,
+            'widget': {
+                'class': field.widget.__class__.__name__
+            }
+        }
+
+        try:
+            d['input_type'] = field.widget.input_type
+        except AttributeError:
+            # some widgets, such as Select do not have an input type
+            # in django < 1.11
+            d['input_type'] = None
+
+        return d
+
     def validate(self, value):
         """
         Used to implement custom cleaning logic for use in forms

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -52,7 +52,22 @@ class BasePreferenceType(AbstractPreference):
         kwargs['help_text'] = self.get('help_text')
         kwargs['widget'] = self.get('widget')
         kwargs['initial'] = self.get('default')
+        kwargs['validators'] = [self.validate]
         return kwargs
+
+    def api_repr(self, value):
+        """
+        Used only to represent a preference value using Rest Framework
+        """
+        return value
+
+    def validate(self, value):
+        """
+        Used to implement custom cleaning logic for use in forms
+        and serializers
+        """
+        return
+
 
 class BooleanPreference(BasePreferenceType):
 
@@ -64,6 +79,7 @@ class BooleanPreference(BasePreferenceType):
         kwargs['required'] = False
         return kwargs
 
+
 class IntegerPreference(BasePreferenceType):
 
     field_class = forms.IntegerField
@@ -71,23 +87,28 @@ class IntegerPreference(BasePreferenceType):
 
 IntPreference = IntegerPreference
 
+
 class DecimalPreference(BasePreferenceType):
 
     field_class = forms.DecimalField
     serializer = DecimalSerializer
+
 
 class FloatPreference(BasePreferenceType):
 
     field_class = forms.FloatField
     serializer = FloatSerializer
 
+
 class StringPreference(BasePreferenceType):
 
     field_class = forms.CharField
     serializer = StringSerializer
 
+
 class LongStringPreference(StringPreference):
     widget = forms.Textarea
+
 
 class ChoicePreference(BasePreferenceType):
 
@@ -97,18 +118,21 @@ class ChoicePreference(BasePreferenceType):
 
     def get_field_kwargs(self):
         field_kwargs = super(ChoicePreference, self).get_field_kwargs()
-
         field_kwargs['choices'] = self.choices or self.field_attribute['initial']
         return field_kwargs
 
 
 def create_deletion_handler(preference):
-    """Will generate a dynamic handler to purge related preference on instance deletion"""
+    """
+    Will generate a dynamic handler to purge related preference
+    on instance deletion
+    """
     def delete_related_preferences(sender, instance, *args, **kwargs):
         queryset = preference.registry.preference_model.objects\
                                       .filter(name=preference.name,
                                               section=preference.section)
-        related_preferences = queryset.filter(raw_value=preference.serializer.serialize(instance))
+        related_preferences = queryset.filter(
+            raw_value=preference.serializer.serialize(instance))
         related_preferences.delete()
     return delete_related_preferences
 
@@ -142,3 +166,8 @@ class ModelChoicePreference(BasePreferenceType):
         kw = super(ModelChoicePreference, self).get_field_kwargs()
         kw['queryset'] = self.get('queryset')
         return kw
+
+    def api_repr(self, value):
+        if not value:
+            return None
+        return value.pk

--- a/dynamic_preferences/users/serializers.py
+++ b/dynamic_preferences/users/serializers.py
@@ -1,0 +1,5 @@
+from dynamic_preferences.api.serializers import PreferenceSerializer
+
+
+class UserPreferenceSerializer(PreferenceSerializer):
+    pass

--- a/dynamic_preferences/users/viewsets.py
+++ b/dynamic_preferences/users/viewsets.py
@@ -1,0 +1,15 @@
+from rest_framework import permissions
+
+from dynamic_preferences.api import viewsets
+
+from . import serializers
+from . import models
+
+
+class UserPreferencesViewSet(viewsets.PerInstancePreferenceViewSet):
+    queryset = models.UserPreferenceModel.objects.all()
+    serializer_class = serializers.UserPreferenceSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_related_instance(self):
+        return self.request.user

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=tests.settings
+
+# -- recommended but optional:
+python_files = tests.py test_*.py *_tests.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,4 @@ django-nose>=1.2
 flake8>=2.1.0
 tox>=1.7.0
 # Additional test requirements go here
-django-rest-framework
+djangorestframework

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,9 +2,12 @@
 coverage
 coveralls
 mock>=1.0.1
-nose>=1.3.0
-django-nose>=1.2
 flake8>=2.1.0
 tox>=1.7.0
 # Additional test requirements go here
+djangorestframework
+pytest
+pytest-cov
+pytest-django
+pytest-sugar
 djangorestframework

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ django-nose>=1.2
 flake8>=2.1.0
 tox>=1.7.0
 # Additional test requirements go here
+django-rest-framework

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django>=1.7
 six
 wheel==0.24.0
 persisting_theory==0.2.1
 # Additional requirements go here
+persisting_theory==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django>=1.7',
+        'django>=1.8',
         'six',
         'persisting_theory==0.2.1',
     ],

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -14,6 +14,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.admin',
+    'rest_framework',
     'dynamic_preferences',
     'dynamic_preferences.users.apps.UserPreferencesConfig',
     'tests.test_app'

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -1,6 +1,7 @@
 from dynamic_preferences.types import *
 from dynamic_preferences.registries import global_preferences_registry
 from dynamic_preferences.users.registries import user_preferences_registry
+from django.forms import ValidationError
 from .models import BlogEntry
 
 
@@ -23,6 +24,14 @@ class MaxUsers(IntPreference):
     section = "user"
     name = "max_users"
     default = 100
+    verbose_name = 'Maximum user count'
+    help_text = 'Be careful with this setting'
+
+    def validate(self, value):
+        # value can't be equal to 1001, no no no!
+        if value == 1001:
+            raise ValidationError('Wrong value!')
+        return value
 
 
 class NoDefault(IntPreference):

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -23,7 +23,6 @@ class BaseTest(object):
 class TestGlobalPreferences(BaseTest, TestCase):
 
     def setUp(self):
-
         self.test_user = User(
             username="test", password="test", email="test@test.com")
         self.test_user.save()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,42 @@
+from __future__ import unicode_literals
+from django.test import TestCase
+from django.core.cache import caches
+
+from dynamic_preferences.registries import (
+    global_preferences_registry as registry
+)
+from dynamic_preferences.models import GlobalPreferenceModel
+
+
+class BaseTest(object):
+
+    def tearDown(self):
+        caches['default'].clear()
+
+
+class TestPreferences(BaseTest, TestCase):
+
+    def test_can_get_preferences_objects_from_manager(self):
+        manager = registry.manager()
+        cached_prefs = dict(manager.all())
+        qs = manager.queryset
+
+        self.assertEqual(
+            len(qs),
+            len(cached_prefs)
+        )
+
+        self.assertEqual(
+            list(qs),
+            list(GlobalPreferenceModel.objects.all())
+        )
+
+    def test_can_get_db_pref_from_manager(self):
+        manager = registry.manager()
+        manager.queryset.delete()
+        pref = manager.get_db_pref(section='test', name='TestGlobal1')
+
+        self.assertEqual(pref.section, 'test')
+        self.assertEqual(pref.name, 'TestGlobal1')
+        self.assertEqual(
+            pref.raw_value, registry.get('test__TestGlobal1').default)

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -11,6 +11,7 @@ from dynamic_preferences import preferences, exceptions
 from dynamic_preferences.types import IntegerPreference
 
 from .test_app import dynamic_preferences_registry as prefs
+from .test_app.models import BlogEntry
 
 
 class BaseTest(object):
@@ -98,10 +99,11 @@ class TestPreferences(BaseTest, TestCase):
         self.assertGreater(len(connection.queries), manager_queries)
 
     def test_can_cache_all_preferences(self):
-
+        blog_entry = BlogEntry.objects.create(title='test', content='test')
         manager = global_preferences_registry.manager()
         manager.all()
-        with self.assertNumQueries(0):
+        with self.assertNumQueries(3):
+            # one request each time we retrieve the blog entry
             manager.all()
             manager.all()
             manager.all()

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,16 +1,19 @@
 from __future__ import unicode_literals
+import json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import caches
 from django.contrib.auth.models import User
-
+from django.core.cache import caches
 from dynamic_preferences.registries import (
     global_preferences_registry as registry
+)
+from dynamic_preferences.users.registries import (
+    user_preferences_registry as user_registry
 )
 from dynamic_preferences.models import GlobalPreferenceModel
 from dynamic_preferences.forms import global_preference_form_builder
 from dynamic_preferences.api import serializers
-
+from dynamic_preferences.users.serializers import UserPreferenceSerializer
 from .test_app.models import BlogEntry
 
 
@@ -20,7 +23,7 @@ class BaseTest(object):
         caches['default'].clear()
 
 
-class TestGlobalPreferences(BaseTest, TestCase):
+class TestSerializers(BaseTest, TestCase):
 
     def test_can_serialize_preference(self):
         manager = registry.manager()
@@ -33,6 +36,7 @@ class TestGlobalPreferences(BaseTest, TestCase):
             data['default'], pref.preference.api_repr(pref.preference.default))
         self.assertEqual(
             data['value'], pref.preference.api_repr(pref.value))
+        self.assertEqual(data['identifier'], pref.preference.identifier())
         self.assertEqual(data['section'], pref.section)
         self.assertEqual(data['name'], pref.name)
         self.assertEqual(data['verbose_name'], pref.preference.verbose_name)
@@ -63,3 +67,153 @@ class TestGlobalPreferences(BaseTest, TestCase):
         is_valid = serializer.is_valid()
         self.assertFalse(is_valid)
         self.assertIn('value', serializer.errors)
+
+    def test_serializer_includes_additional_data_if_any(self):
+        user = User(
+            username="user",
+            email="user@user.com")
+        user.set_password('test')
+        user.save()
+
+        manager = user_registry.manager(instance=user)
+        pref = manager.get_db_pref(
+            section='user', name='favorite_vegetable')
+
+        serializer = UserPreferenceSerializer(pref)
+        self.assertEqual(
+            serializer.data['additional_data']['choices'],
+            pref.preference.choices)
+
+
+class TestViewSets(BaseTest, TestCase):
+    def setUp(self):
+        self.admin = User(
+            username="admin",
+            email="admin@admin.com",
+            is_superuser=True,
+            is_staff=True)
+        self.admin.set_password('test')
+        self.admin.save()
+
+    def test_global_preference_list_requires_permission(self):
+        url = reverse('api:global-list')
+
+        # anonymous
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        # not authorized
+        user = User(
+            username="user",
+            email="user@user.com")
+        user.set_password('test')
+        user.save()
+
+        self.client.login(username='test', password='test')
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_list_preferences(self):
+        manager = registry.manager()
+        url = reverse('api:global-list')
+        self.client.login(username='admin', password="test")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(len(payload), len(registry.preferences()))
+
+        for e in payload:
+            pref = manager.get_db_pref(section=e['section'], name=e['name'])
+            serializer = serializers.GlobalPreferenceSerializer(pref)
+            self.assertEqual(pref.preference.identifier(), e['identifier'])
+
+    def test_can_detail_preference(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+        url = reverse(
+            'api:global-detail',
+            kwargs={'pk': pref.preference.identifier()})
+        self.client.login(username='admin', password="test")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(pref.preference.identifier(), payload['identifier'])
+        self.assertEqual(pref.value, payload['value'])
+
+    def test_can_update_preference(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+        url = reverse(
+            'api:global-detail',
+            kwargs={'pk': pref.preference.identifier()})
+        self.client.login(username='admin', password="test")
+        response = self.client.patch(
+            url, json.dumps({'value': 16}), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        pref = manager.get_db_pref(section='user', name='max_users')
+
+        self.assertEqual(pref.value, 16)
+
+    def test_can_update_multiple_preferences(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+        url = reverse('api:global-bulk')
+        self.client.login(username='admin', password="test")
+        payload = {
+            'user__max_users': 16,
+            'user__registration_allowed': True,
+        }
+        response = self.client.post(
+            url, json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        pref1 = manager.get_db_pref(section='user', name='max_users')
+        pref2 = manager.get_db_pref(
+            section='user', name='registration_allowed')
+
+        self.assertEqual(pref1.value, 16)
+        self.assertEqual(pref2.value, True)
+
+    def test_update_preference_returns_validation_error(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+        url = reverse(
+            'api:global-detail',
+            kwargs={'pk': pref.preference.identifier()})
+        self.client.login(username='admin', password="test")
+        response = self.client.patch(
+            url, json.dumps({'value': 1001}), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        payload = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(payload['value'], ['Wrong value!'])
+
+    def test_update_multiple_preferences_with_validation_errors_rollback(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+        url = reverse('api:global-bulk')
+        self.client.login(username='admin', password="test")
+        payload = {
+            'user__max_users': 1001,
+            'user__registration_allowed': True,
+        }
+        response = self.client.post(
+            url, json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        errors = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(
+            errors[pref.preference.identifier()]['value'], ['Wrong value!'])
+
+        pref1 = manager.get_db_pref(section='user', name='max_users')
+        pref2 = manager.get_db_pref(
+            section='user', name='registration_allowed')
+
+        self.assertEqual(pref1.value, pref1.preference.default)
+        self.assertEqual(pref2.value, pref2.preference.default)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,0 +1,65 @@
+from __future__ import unicode_literals
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.core.cache import caches
+from django.contrib.auth.models import User
+
+from dynamic_preferences.registries import (
+    global_preferences_registry as registry
+)
+from dynamic_preferences.models import GlobalPreferenceModel
+from dynamic_preferences.forms import global_preference_form_builder
+from dynamic_preferences.api import serializers
+
+from .test_app.models import BlogEntry
+
+
+class BaseTest(object):
+
+    def tearDown(self):
+        caches['default'].clear()
+
+
+class TestGlobalPreferences(BaseTest, TestCase):
+
+    def test_can_serialize_preference(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+
+        serializer = serializers.GlobalPreferenceSerializer(pref)
+        data = serializer.data
+
+        self.assertEqual(
+            data['default'], pref.preference.api_repr(pref.preference.default))
+        self.assertEqual(
+            data['value'], pref.preference.api_repr(pref.value))
+        self.assertEqual(data['section'], pref.section)
+        self.assertEqual(data['name'], pref.name)
+        self.assertEqual(data['verbose_name'], pref.preference.verbose_name)
+        self.assertEqual(data['help_text'], pref.preference.help_text)
+
+    def test_can_change_preference_value_using_serializer(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+        data = {'value': 666}
+        serializer = serializers.GlobalPreferenceSerializer(pref, data=data)
+
+        is_valid = serializer.is_valid()
+        self.assertTrue(is_valid)
+
+        serializer.save()
+        pref = manager.get_db_pref(section='user', name='max_users')
+
+        self.assertEqual(pref.value, data['value'])
+
+    def test_serializer_also_uses_custom_clean_method(self):
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='user', name='max_users')
+
+        # will fail because of preference cleaning
+        data = {'value': 1001}
+        serializer = serializers.GlobalPreferenceSerializer(pref, data=data)
+
+        is_valid = serializer.is_valid()
+        self.assertFalse(is_valid)
+        self.assertIn('value', serializer.errors)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -41,6 +41,9 @@ class TestSerializers(BaseTest, TestCase):
         self.assertEqual(data['name'], pref.name)
         self.assertEqual(data['verbose_name'], pref.preference.verbose_name)
         self.assertEqual(data['help_text'], pref.preference.help_text)
+        self.assertEqual(data['field']['class'], 'IntegerField')
+        self.assertEqual(data['field']['input_type'], 'number')
+        self.assertEqual(data['field']['widget']['class'], 'NumberInput')
 
     def test_can_change_preference_value_using_serializer(self):
         manager = registry.manager()

--- a/tests/test_user_preferences.py
+++ b/tests/test_user_preferences.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import json
 
 from django.test import LiveServerTestCase, TestCase
 from django.test.utils import override_settings
@@ -7,8 +8,10 @@ from django.contrib.auth.models import User
 from django.core.cache import caches
 from django.db import IntegrityError
 
-from dynamic_preferences.users.registries import user_preferences_registry
+from dynamic_preferences.users.registries import (
+    user_preferences_registry as registry)
 from dynamic_preferences.users.models import UserPreferenceModel
+from dynamic_preferences.users import serializers
 from dynamic_preferences.managers import PreferencesManager
 from dynamic_preferences.users.forms import user_preference_form_builder
 from .test_app.dynamic_preferences_registry import *
@@ -28,7 +31,7 @@ class TestModels(BaseTest, TestCase):
         u.save()
 
         self.assertEqual(
-            len(u.preferences), len(user_preferences_registry.preferences()))
+            len(u.preferences), len(registry.preferences()))
 
 
 class TestDynamicPreferences(BaseTest, TestCase):
@@ -66,7 +69,7 @@ class TestDynamicPreferences(BaseTest, TestCase):
 
     def test_preference_value_set_to_default(self):
 
-        pref = user_preferences_registry.get("TestUserPref1", "test")
+        pref = registry.get("TestUserPref1", "test")
 
         value = self.test_user.preferences['test__TestUserPref1']
         self.assertEqual(pref.default, value)
@@ -138,3 +141,126 @@ class TestViews(BaseTest, LiveServerTestCase):
             self.henri.preferences['misc__favourite_colour'], 'Purple')
         self.assertEqual(
             self.henri.preferences['misc__is_zombie'], False)
+
+
+class TestViewSets(BaseTest, TestCase):
+    def setUp(self):
+        self.user = User(
+            username="user",
+            email="user@user.com",
+            is_superuser=True,
+            is_staff=True)
+        self.user.set_password('test')
+        self.user.save()
+
+    def test_preference_list_requires_authentication(self):
+        url = reverse('api:user-list')
+
+        # anonymous
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_list_preferences(self):
+        manager = registry.manager(instance=self.user)
+        url = reverse('api:user-list')
+        self.client.login(username='user', password="test")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(len(payload), len(registry.preferences()))
+
+        for e in payload:
+            pref = manager.get_db_pref(section=e['section'], name=e['name'])
+            serializer = serializers.UserPreferenceSerializer(pref)
+            self.assertEqual(pref.preference.identifier(), e['identifier'])
+
+    def test_can_detail_preference(self):
+        manager = registry.manager(instance=self.user)
+        pref = manager.get_db_pref(section='user', name='favorite_vegetable')
+        url = reverse(
+            'api:user-detail',
+            kwargs={'pk': pref.preference.identifier()})
+        self.client.login(username='user', password="test")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(pref.preference.identifier(), payload['identifier'])
+        self.assertEqual(pref.value, payload['value'])
+
+    def test_can_update_preference(self):
+        manager = registry.manager(instance=self.user)
+        pref = manager.get_db_pref(section='user', name='favorite_vegetable')
+        url = reverse(
+            'api:user-detail',
+            kwargs={'pk': pref.preference.identifier()})
+        self.client.login(username='user', password="test")
+        response = self.client.patch(
+            url, json.dumps({'value': 'P'}), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        pref = manager.get_db_pref(section='user', name='favorite_vegetable')
+
+        self.assertEqual(pref.value, 'P')
+
+    def test_can_update_multiple_preferences(self):
+        manager = registry.manager(instance=self.user)
+        pref = manager.get_db_pref(section='user', name='favorite_vegetable')
+        url = reverse('api:user-bulk')
+        self.client.login(username='user', password="test")
+        payload = {
+            'user__favorite_vegetable': 'C',
+            'misc__favourite_colour': 'Blue',
+        }
+        response = self.client.post(
+            url, json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        pref1 = manager.get_db_pref(section='user', name='favorite_vegetable')
+        pref2 = manager.get_db_pref(
+            section='misc', name='favourite_colour')
+
+        self.assertEqual(pref1.value, 'C')
+        self.assertEqual(pref2.value, 'Blue')
+
+    def test_update_preference_returns_validation_error(self):
+        manager = registry.manager(instance=self.user)
+        pref = manager.get_db_pref(section='user', name='favorite_vegetable')
+        url = reverse(
+            'api:user-detail',
+            kwargs={'pk': pref.preference.identifier()})
+        self.client.login(username='user', password="test")
+        response = self.client.patch(
+            url, json.dumps({'value': 'Z'}), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        payload = json.loads(response.content.decode('utf-8'))
+
+        self.assertIn('valid choice', payload['value'][0])
+
+    def test_update_multiple_preferences_with_validation_errors_rollback(self):
+        manager = registry.manager(instance=self.user)
+        pref = manager.get_db_pref(section='user', name='favorite_vegetable')
+        url = reverse('api:user-bulk')
+        self.client.login(username='user', password="test")
+        payload = {
+            'user__favorite_vegetable': 'Z',
+            'misc__favourite_colour': 'Blue',
+        }
+        response = self.client.post(
+            url, json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        errors = json.loads(response.content.decode('utf-8'))
+        self.assertIn(
+            'valid choice',
+            errors[pref.preference.identifier()]['value'][0])
+
+        pref1 = manager.get_db_pref(section='user', name='favorite_vegetable')
+        pref2 = manager.get_db_pref(
+            section='misc', name='favourite_colour')
+
+        self.assertEqual(pref1.value, pref1.preference.default)
+        self.assertEqual(pref2.value, pref2.preference.default)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,11 +1,24 @@
 from django.conf.urls import include, url
-from dynamic_preferences import views
 from django.contrib import admin
+from rest_framework import routers
+
+from dynamic_preferences import views
+from dynamic_preferences.api.viewsets import GlobalPreferencesViewSet
+from dynamic_preferences.users.viewsets import UserPreferencesViewSet
+
 admin.autodiscover()
+
+router = routers.SimpleRouter()
+router.register(r'global', GlobalPreferencesViewSet, base_name='global')
+router.register(r'user', UserPreferencesViewSet, base_name='user')
+# router.register(r'user', AccountViewSet)
 
 
 urlpatterns = [
     url(r'^', include("dynamic_preferences.urls")),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^test/template$',views.RegularTemplateView.as_view(), name="dynamic_preferences.test.templateview"),
+    url(r'^test/template$',
+        views.RegularTemplateView.as_view(),
+        name="dynamic_preferences.test.templateview"),
+    url(r'^api', include(router.urls, namespace='api'))
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,29 +4,33 @@
 # and then run "tox" from this directory.
 
 [tox]
-skipsdist = True
 envlist =
-    py{27,34,35}-django{17,18,19,110,111}
+    {py27,py33,py34,py35}-django-18
+    {py27,py34,py35}-django-19
+    {py27,py34,py35}-django-110
+    {py27,py34,py35,py36}-django-111
+    {py35,py36}-django-master
+
 
 [testenv]
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
 
 setenv =
     PYTHONPATH = {toxinidir}
 commands = pytest {posargs}
 deps =
-    persisting_theory==0.2.1
-    pytest
-    pytest-sugar
-    pytest-django
-    six
-    djangorestframework
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<2
+    django-16: Django>=1.6,<1.7
+    django-17: Django>=1.7,<1.8
+    django-18: Django>=1.8,<1.9
+    django-19: Django>=1.9,<1.10
+    django-110: Django>=1.10,<1.11
+    django-111: Django>=1.11,<2
+    django-master: https://github.com/django/django/archive/master.tar.gz
+    -r{toxinidir}/requirements-test.txt
+
+
+basepython =
+    py36: python3.6
+    py35: python3.5
+    py34: python3.4
+    py33: python3.3
+    py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{27,34,35}-django{17,18,19,110}
+    py{27,34,35}-django{17,18,19,110,111}
 
 [testenv]
 basepython =
@@ -16,14 +16,17 @@ basepython =
 
 setenv =
     PYTHONPATH = {toxinidir}
-commands = python runtests.py {posargs}
+commands = pytest {posargs}
 deps =
     persisting_theory==0.2.1
-    nose
-    django-nose
+    pytest
+    pytest-sugar
+    pytest-django
     six
+    djangorestframework
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2


### PR DESCRIPTION
This implements API viewsets and serializers (based on Django Rest Framework) to make it easier to interract with preferences remotely. This includes:

- [x] Retrieve a list of preferences
- [x] Retrieve a single preference
- [x] Update a list of preferences values
- [x] Update a single preference
- [x] Permission checks

This also includes a few unrelated changes:

- [x] A big reduction of database and cache queries (by a factor 2 or 3), as the manager code was not optimized at all
- [x] Switched from nose to pytest for test execution
- [x] Added a `validate` method on preferences you can override to implement your own custom validation logic (this is triggered when saving preferences from forms and serializers)


What needs to be done:

- [x] Documentation!

Note: the PR is quite big but almost 50% of it are related to tests.