### PR TITLE
Rework on #37 by @macolo to implement File preference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,11 +12,14 @@
 # serve to show the default.
 
 import sys, os
-
+import django
+from django.conf import settings
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
+settings.configure(DEBUG=True)
+django.setup()
 
 cwd = os.getcwd()
 parent = os.path.dirname(cwd)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contents:
    installation
    quickstart
    bind_preferences_to_models
+   preference_types
    rest_api
    lifecycle
    upgrade

--- a/docs/preference_types.rst
+++ b/docs/preference_types.rst
@@ -1,0 +1,6 @@
+Preference types
+================
+
+
+.. automodule:: dynamic_preferences.types
+    :members:

--- a/dynamic_preferences/settings.py
+++ b/dynamic_preferences/settings.py
@@ -22,6 +22,10 @@ DEFAULTS = {
     'ENABLE_USER_PREFERENCES': True,
     'ENABLE_CACHE': True,
     'VALIDATE_NAMES': True,
+    'FILE_PREFERENCE_UPLOAD_DIR': 'dynamic_preferences',
+    # this will be used to cache empty values, since some cache backends
+    # does not support it on get_many
+    'CACHE_NONE_VALUE': '__dynamic_preferences_empty_value'
 }
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,4 @@
+import tempfile
 
 DEBUG = True
 TEMPLATE_DEBUG = True
@@ -22,6 +23,8 @@ INSTALLED_APPS = [
 SITE_ID = 1
 SECRET_KEY = 'FDLDSKSDJHF'
 STATIC_URL = '/static/'
+MEDIA_URL = '/media/'
+MEDIA_ROOT = tempfile.mkdtemp()
 NOSE_ARGS = ['-s']
 MIDDLEWARE_CLASSES =  (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -57,6 +57,12 @@ class FeaturedBlogEntry(ModelChoicePreference):
         return self.queryset.first()
 
 
+@global_preferences_registry.register
+class BlogLogo(FilePreference):
+    section = "blog"
+    name = "logo"
+
+
 @user_preferences_registry.register
 class FavoriteVegetable(ChoicePreference):
 

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -38,6 +38,7 @@ class TestGlobalPreferences(BaseTest, TestCase):
             u'user__max_users': 100,
             u'user__items_per_page': 25,
             u'blog__featured_entry': None,
+            u'blog__logo': None,
             u'user__registration_allowed': False}
         self.assertDictEqual(manager.all(), expected)
 
@@ -94,7 +95,7 @@ class TestViews(BaseTest, LiveServerTestCase):
         url = reverse("dynamic_preferences.global")
         self.client.login(username='admin', password="test")
         response = self.client.get(url)
-        self.assertEqual(len(response.context['form'].fields), 8)
+        self.assertEqual(len(response.context['form'].fields), 9)
         self.assertEqual(
             response.context['registry'], registry)
 
@@ -133,6 +134,7 @@ class TestViews(BaseTest, LiveServerTestCase):
             'test__TestGlobal3': True,
             'no_section': True,
             'blog__featured_entry': blog_entry.pk,
+            'blog__logo': None,
         }
         response = self.client.post(url, data)
         for key, expected_value in data.items():


### PR DESCRIPTION
This is based on the work by @macolo in #37 to implement a File preference type, with various changes though, as the original PR was submitted 18 months ago.

It includes:

- [x] Unittests
- [x] Compatibility with any storage backend (at least theorically, because we never manipulate the filesystem directly)
- [x] `FileField` like API;

We still need the following though:

- [x] API and form integrations
- [x] Documentation

@fabrixxm you can start review and test it if you want, although I suspect forms won't work out of the box in the current state (that would be a good surprise if they did).
