### PR TITLE
Fix a data loss issue where preferences values are reset to default

### DIFF
--- a/dynamic_preferences/managers.py
+++ b/dynamic_preferences/managers.py
@@ -175,12 +175,11 @@ class PreferencesManager(collections.Mapping):
         m.value = value
         raw_value = m.raw_value
 
-        db_pref, updated = self.model.objects.update_or_create(
-            defaults={
-                'raw_value': raw_value
-            },
-            **kwargs
-        )
+        db_pref, created = self.model.objects.get_or_create(**kwargs)
+        if created and db_pref.raw_value != raw_value:
+            db_pref.raw_value = raw_value
+            db_pref.save()
+
         return db_pref
 
     def all(self):
@@ -206,7 +205,7 @@ class PreferencesManager(collections.Mapping):
                     name=preference.name,
                     value=default)
 
-                a[preference.identifier()] = default
+                a[preference.identifier()] = db_pref.value
 
         return a
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 from django.test import TestCase
 from django.core.cache import caches
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
 
 from dynamic_preferences.registries import (
     global_preferences_registry as registry
@@ -40,3 +42,59 @@ class TestPreferences(BaseTest, TestCase):
         self.assertEqual(pref.name, 'TestGlobal1')
         self.assertEqual(
             pref.raw_value, registry.get('test__TestGlobal1').default)
+
+    def test_do_not_restore_default_when_calling_all(self):
+        manager = registry.manager()
+
+        new_value = 'test_new_value'
+        manager['test__TestGlobal1'] = new_value
+        self.assertEqual(manager['test__TestGlobal1'], new_value)
+        caches['default'].clear()
+        manager.all()
+        caches['default'].clear()
+        self.assertEqual(manager['test__TestGlobal1'], new_value)
+        self.assertEqual(manager.all()['test__TestGlobal1'], new_value)
+
+    def test_invalidates_cache_when_saving_database_preference(self):
+        manager = registry.manager()
+        caches['default'].clear()
+        new_value = 'test_new_value'
+        key = manager.get_cache_key('test', 'TestGlobal1')
+        manager['test__TestGlobal1'] = new_value
+
+        pref = manager.get_db_pref(section='test', name='TestGlobal1')
+        self.assertEqual(pref.raw_value, new_value)
+        self.assertEqual(manager.cache.get(key), new_value)
+
+        pref.raw_value = 'reset'
+        pref.save()
+
+        self.assertEqual(manager.cache.get(key), 'reset')
+
+    def test_invalidates_cache_when_saving_from_admin(self):
+        admin = User(
+            username="admin",
+            email="admin@admin.com",
+            is_superuser=True,
+            is_staff=True)
+        admin.set_password('test')
+        admin.save()
+        self.client.login(username='admin', password="test")
+
+        manager = registry.manager()
+        pref = manager.get_db_pref(section='test', name='TestGlobal1')
+        url = reverse(
+            'admin:dynamic_preferences_globalpreferencemodel_change',
+            args=(pref.id,)
+        )
+        key = manager.get_cache_key('test', 'TestGlobal1')
+
+        response = self.client.post(url, {'raw_value': 'reset1'})
+
+        self.assertEqual(manager.cache.get(key), 'reset1')
+        self.assertEqual(manager.all()['test__TestGlobal1'], 'reset1')
+
+        response = self.client.post(url, {'raw_value': 'reset2'})
+
+        self.assertEqual(manager.cache.get(key), 'reset2')
+        self.assertEqual(manager.all()['test__TestGlobal1'], 'reset2')


### PR DESCRIPTION
this is a critical issue, because due to a logical error in `manager.create_db_pref`, preferences values where systematically restored to their default value.