### PR TITLE
Cache values when queried in all()

### DIFF
--- a/dynamic_preferences/managers.py
+++ b/dynamic_preferences/managers.py
@@ -205,6 +205,7 @@ class PreferencesManager(collections.Mapping):
                     section=preference.section.name,
                     name=preference.name,
                     value=default)
+                self.to_cache(db_pref)
 
                 a[preference.identifier()] = db_pref.value
 


### PR DESCRIPTION
The symptom I'm getting is the following: When `Manager.by_name()` is called repeatedly, it hits the database with a query per preference for most preferences (I have about 100 of them) on every page load. On further inspection, it seems the cache finds only those preferences that have previously been referenced directly, as opposed to via `by_name()` (and hence via `all()`).

For context, we have a context processor that provides access to the preferences associated with a particular model (called `Tournament`), that you can see in [this file here](https://github.com/czlee/tabbycat/blob/51b5faf9e117ac6460bb89d155dd4c9ac0a5355a/tabbycat/utils/context_processors.py#L18). It's similar to the context processor in the library for global preferences, just for a particular model instance.

I found that adding this line changes behavior as follows: On the first page load, it hits the database once for every preference, but then on the second page load, it finds everything in the cache. **But** I'm not fluent in how the cache is managed in this library, so I'm not sure if this might have undesirable side effects, _e.g._ with stale cached entries?

I suppose it'd also be nice to load them all from the database in a single database hit, which I might give a go in a separate PR if I figure it out?