### PR TITLE
Retrieve existing preferences in bulk

### DIFF
--- a/dynamic_preferences/managers.py
+++ b/dynamic_preferences/managers.py
@@ -216,7 +216,8 @@ class PreferencesManager(collections.Mapping):
                 section=preference.section.name,
                 name=preference.name,
                 value=default)
-            self.to_cache(db_pref)
+            # no need to cache, since it should be cached on creation
+            # (and since it's missing, it should always be created)
 
             a[preference.identifier()] = db_pref.value
 


### PR DESCRIPTION
As discussed in #91.

It took me a few iterations to notice that I was basically duplicating `load_from_db()` (as you can see from the commit history), so the current version just calls `load_from_db()`. I suspect filtering the queryset for just those fields missing from the cache would add more complexity than it's worth, so I ended up getting it to retrieve everything unless _everything_ was found in the cache.

Then, since you already have all the data, you may as well use it, so in line 203 it just overwrites the value retrieved from cache. In practice, unless the cache has entries that the database doesn't, line 203 is probably the same as `return self.load_from_db()`.

I sort of wondered whether it should include fallback preferences in the returned dict, and initially got it to do so, and then decided you probably had some reason for not doing so in the current implementation. So the version in 45034c9 doesn't include fallback preferences. (For my application it doesn't really matter, at worst you'll just have stray entries in the dict that you'll never ask about.)