### PR TITLE
Fixed #97 (and potentially other issues), missing to_python() call in REST serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ docs/_build
 
 example/*.sqlite*
 .idea/
+.python-version
+.cache

--- a/dynamic_preferences/api/serializers.py
+++ b/dynamic_preferences/api/serializers.py
@@ -60,6 +60,7 @@ class PreferenceSerializer(serializers.Serializer):
         We call validation from the underlying form field
         """
         field = self.instance.preference.setup_field()
+        value = field.to_python(value)
         field.validate(value)
         field.run_validators(value)
         return value

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from dynamic_preferences.types import *
 from dynamic_preferences.registries import global_preferences_registry
 from dynamic_preferences.users.registries import user_preferences_registry
@@ -41,7 +43,6 @@ class NoDefault(IntPreference):
 
 @global_preferences_registry.register
 class ItemsPerPage(IntPreference):
-
     section = "user"
     name = "items_per_page"
     default = 25
@@ -63,9 +64,15 @@ class BlogLogo(FilePreference):
     name = "logo"
 
 
+@global_preferences_registry.register
+class BlogCost(DecimalPreference):
+    section = 'type'
+    name = 'cost'
+    default = Decimal(0)
+
+
 @user_preferences_registry.register
 class FavoriteVegetable(ChoicePreference):
-
     choices = (
         ("C", "Carrot"),
         ("T", "Tomato. I know, it's not a vegetable"),

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+
+from decimal import Decimal
 from django.test import LiveServerTestCase, TestCase
 from django.core.urlresolvers import reverse
 from django.core.management import call_command
@@ -35,6 +37,7 @@ class TestGlobalPreferences(BaseTest, TestCase):
             u'test__TestGlobal1': u'default value',
             u'test__TestGlobal2': False,
             u'test__TestGlobal3': False,
+            u'type__cost': Decimal(0),
             u'no_section': False,
             u'user__max_users': 100,
             u'user__items_per_page': 25,
@@ -96,7 +99,7 @@ class TestViews(BaseTest, LiveServerTestCase):
         url = reverse("dynamic_preferences.global")
         self.client.login(username='admin', password="test")
         response = self.client.get(url)
-        self.assertEqual(len(response.context['form'].fields), 9)
+        self.assertEqual(len(response.context['form'].fields), 10)
         self.assertEqual(
             response.context['registry'], registry)
 
@@ -136,6 +139,7 @@ class TestViews(BaseTest, LiveServerTestCase):
             'no_section': True,
             'blog__featured_entry': blog_entry.pk,
             'blog__logo': None,
+            'type__cost': 1,
         }
         response = self.client.post(url, data)
         for key, expected_value in data.items():


### PR DESCRIPTION
Also get test from #98 to ensure the issue won't happen again.