### PR TITLE
Add datetime preference type

### DIFF
--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -3,15 +3,12 @@ You'll find here the final, concrete classes of preferences you can use
 in your own project.
 
 """
-import datetime
 from django import forms
 from django.db.models.signals import pre_delete
-from django.utils.translation import ugettext_lazy as _
-from django.utils.functional import cached_property
 
 from django.core.files.storage import default_storage
 
-from .preferences import AbstractPreference, Section
+from .preferences import AbstractPreference
 from dynamic_preferences.serializers import *
 from dynamic_preferences.settings import preferences_settings
 
@@ -411,3 +408,11 @@ class DatePreference(BasePreferenceType):
     """
     field_class = forms.DateField
     serializer = DateSerializer
+
+    
+class DateTimePreference(BasePreferenceType):
+    """
+        A preference type that stores a datetime.
+    """
+    field_class = forms.DateTimeField
+    serializer = DateTimeSerializer

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+from django.utils.timezone import FixedOffset
+
 from dynamic_preferences.types import *
 from dynamic_preferences.registries import global_preferences_registry
 from dynamic_preferences.users.registries import user_preferences_registry
@@ -170,3 +172,10 @@ class RegistrationDate(DatePreference):
     section = 'company'
     name = 'RegistrationDate'
     default = date(1998, 9, 4)
+
+
+@global_preferences_registry.register
+class BirthDateTime(DateTimePreference):
+    section = 'child'
+    name = 'BirthDateTime'
+    default = datetime(1992, 5, 4, 3, 4, 10, 150, FixedOffset(offset=330))

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from django.core.cache import caches
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.utils.timezone import FixedOffset, get_default_timezone
+from django.utils.timezone import FixedOffset, make_aware
 
 from dynamic_preferences.registries import (
     global_preferences_registry as registry
@@ -161,7 +161,7 @@ class TestViews(BaseTest, LiveServerTestCase):
             if name == 'featured_entry':
                 expected_value = blog_entry
             if name == 'BirthDateTime':
-                expected_value = expected_value.astimezone(get_default_timezone())
+                expected_value = make_aware(expected_value)
 
             self.assertEqual(p.value, expected_value)
 

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -2,13 +2,14 @@ from __future__ import unicode_literals
 
 from decimal import Decimal
 
-from datetime import timedelta, date
+from datetime import date, timedelta, datetime
 from django.test import LiveServerTestCase, TestCase
 from django.core.urlresolvers import reverse
 from django.core.management import call_command
 from django.core.cache import caches
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils.timezone import FixedOffset, get_default_timezone
 
 from dynamic_preferences.registries import (
     global_preferences_registry as registry
@@ -47,6 +48,7 @@ class TestGlobalPreferences(BaseTest, TestCase):
             u'blog__featured_entry': None,
             u'blog__logo': None,
             u'company__RegistrationDate': date(1998, 9, 4),
+            u'child__BirthDateTime': datetime(1992, 5, 4, 3, 4, 10, 150, tzinfo=FixedOffset(offset=330)),
             u'user__registration_allowed': False}
         self.assertDictEqual(manager.all(), expected)
 
@@ -103,7 +105,7 @@ class TestViews(BaseTest, LiveServerTestCase):
         url = reverse("dynamic_preferences.global")
         self.client.login(username='admin', password="test")
         response = self.client.get(url)
-        self.assertEqual(len(response.context['form'].fields), 12)
+        self.assertEqual(len(response.context['form'].fields), 13)
         self.assertEqual(
             response.context['registry'], registry)
 
@@ -144,6 +146,7 @@ class TestViews(BaseTest, LiveServerTestCase):
             'blog__featured_entry': blog_entry.pk,
             'blog__logo': None,
             'company__RegistrationDate': date(1976, 4, 1),
+            'child__BirthDateTime': datetime.now(),
             'type__cost': 1,
             'exam__duration': timedelta(hours=5),
         }
@@ -157,6 +160,9 @@ class TestViews(BaseTest, LiveServerTestCase):
             p = GlobalPreferenceModel.objects.get(name=name, section=section)
             if name == 'featured_entry':
                 expected_value = blog_entry
+            if name == 'BirthDateTime':
+                expected_value = expected_value.astimezone(get_default_timezone())
+
             self.assertEqual(p.value, expected_value)
 
     def test_preference_are_updated_on_form_submission_by_section(self):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 import os
 import decimal
 
-from datetime import timedelta, date
+from datetime import date, timedelta, datetime
 from django import forms
 from django.test import TestCase
 from django.db.models import signals
@@ -124,6 +124,17 @@ class TestTypes(BaseTest, TestCase):
         preference = P()
 
         self.assertEqual(preference.field.initial, date.today())
+
+    @override_settings(DYNAMIC_PREFERENCES={'VALIDATE_NAMES': False})
+    def test_datetime_preference(self):
+        initial_date_time = datetime(2017, 10, 4, 23, 7, 20, 682380)
+
+        class P(types.DateTimePreference):
+            default = initial_date_time
+
+        preference = P()
+
+        self.assertEqual(preference.field.initial, initial_date_time)
 
 
 class TestFilePreference(BaseTest, TestCase):


### PR DESCRIPTION
For #8 

@EliotBerriot I just finished adding `DateTimePreference`. Some things to note,

1. I'm serializing to isoformat
2. I've handled the case when `settings.USE_TZ=false` in which case we'll serialise without a timezone info.
3. I've also tested that if user sets `settings.TIME_ZONE` to a valid timezone name then the I serialise to that timezone.

Let me know how this looks :)