### PR TITLE
use path as returned by storage save method

### DIFF
--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -273,9 +273,9 @@ class FileSerializer(InstanciatedSerializer):
         path = os.path.join(
             self.preference.get_upload_path(),
             f.name)
-        self.preference.get_file_storage().save(path, f)
+        saved_path = self.preference.get_file_storage().save(path, f)
 
-        return path
+        return saved_path
 
     def to_python(self, value, **kwargs):
         if not value:

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -67,6 +67,12 @@ class BlogLogo(FilePreference):
 
 
 @global_preferences_registry.register
+class BlogLogo2(FilePreference):
+    section = "blog"
+    name = "logo2"
+
+
+@global_preferences_registry.register
 class BlogCost(DecimalPreference):
     section = 'type'
     name = 'cost'

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -47,6 +47,7 @@ class TestGlobalPreferences(BaseTest, TestCase):
             u'user__items_per_page': 25,
             u'blog__featured_entry': None,
             u'blog__logo': None,
+            u'blog__logo2': None,
             u'company__RegistrationDate': date(1998, 9, 4),
             u'child__BirthDateTime': datetime(1992, 5, 4, 3, 4, 10, 150, tzinfo=FixedOffset(offset=330)),
             u'user__registration_allowed': False}
@@ -105,7 +106,7 @@ class TestViews(BaseTest, LiveServerTestCase):
         url = reverse("dynamic_preferences.global")
         self.client.login(username='admin', password="test")
         response = self.client.get(url)
-        self.assertEqual(len(response.context['form'].fields), 13)
+        self.assertEqual(len(response.context['form'].fields), 14)
         self.assertEqual(
             response.context['registry'], registry)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -161,7 +161,7 @@ class TestFilePreference(BaseTest, TestCase):
         )
 
     def test_file_preference_store_file_path(self):
-        f = SimpleUploadedFile('test_file.txt', 'hello world'.encode('utf-8'))
+        f = SimpleUploadedFile('test_file_1ce410e5-6814-4910-afd7-be1486d3644f.txt', 'hello world'.encode('utf-8'))
         p = global_preferences_registry.get(section='blog', name='logo')
         manager = global_preferences_registry.manager()
         manager['blog__logo'] = f
@@ -179,8 +179,37 @@ class TestFilePreference(BaseTest, TestCase):
                 settings.MEDIA_ROOT, p.get_upload_path(), f.name)
             )
 
+    def test_file_preference_conflicting_file_names(self):
+        '''
+        f2 should have a different file name to f, since Django storage needs
+        to differentiate between the two
+        '''
+        f = SimpleUploadedFile('test_file_c95d02ef-0e5d-4d36-98c0-1b54505860d0.txt', 'hello world'.encode('utf-8'))
+        f2 = SimpleUploadedFile('test_file_c95d02ef-0e5d-4d36-98c0-1b54505860d0.txt', 'hello world 2'.encode('utf-8'))
+        p = global_preferences_registry.get(section='blog', name='logo')
+        manager = global_preferences_registry.manager()
+
+        manager['blog__logo'] = f
+        manager['blog__logo2'] = f2
+
+        self.assertEqual(
+            manager['blog__logo2'].read(),
+            b'hello world 2')
+        self.assertEqual(
+            manager['blog__logo'].read(),
+            b'hello world')
+
+        self.assertNotEqual(
+            manager['blog__logo'].url,
+            manager['blog__logo2'].url
+        )
+        self.assertNotEqual(
+            manager['blog__logo'].path,
+            manager['blog__logo2'].path
+        )
+
     def test_can_delete_file_preference(self):
-        f = SimpleUploadedFile('test_file.txt', 'hello world'.encode('utf-8'))
+        f = SimpleUploadedFile('test_file_bf2e72ef-092f-4a71-9cda-f2442d6166d0.txt', 'hello world'.encode('utf-8'))
         p = global_preferences_registry.get(section='blog', name='logo')
         manager = global_preferences_registry.manager()
         manager['blog__logo'] = f
@@ -194,7 +223,7 @@ class TestFilePreference(BaseTest, TestCase):
         self.assertFalse(os.path.exists(path))
 
     def test_file_preference_api_repr_returns_path(self):
-        f = SimpleUploadedFile('test_file.txt', 'hello world'.encode('utf-8'))
+        f = SimpleUploadedFile('test_file_24485a80-8db9-4191-ae49-da7fe2013794.txt', 'hello world'.encode('utf-8'))
         p = global_preferences_registry.get(section='blog', name='logo')
         manager = global_preferences_registry.manager()
         manager['blog__logo'] = f


### PR DESCRIPTION
fixes #111 by ensuring that if the file saving process modified the path
name, the modifications are saved back to the preference, rather than using the
original file path.