### PR TITLE
Fix #127: removed typo in API code that could cause a crash

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+(unreleased)
+******************
+
+* Fix #127: removed typo in API code that could cause a crash
+
+
+
 1.4.2 (06-11-2017)
 ******************
 

--- a/dynamic_preferences/api/viewsets.py
+++ b/dynamic_preferences/api/viewsets.py
@@ -94,7 +94,7 @@ class PreferenceViewSet(
                 except exceptions.NotFoundInRegistry:
                     errors[identifier] = 'invalid preference'
         except (TypeError, AttributeError):
-            return Reponse('invalid payload', status=400)
+            return Response('invalid payload', status=400)
 
         if errors:
             return Response(errors, status=400)


### PR DESCRIPTION
Fix #127: removed typo in API code that could cause a crash