### PR TITLE
Added on_dete=models.CASCADE to migrations for Django 2.0 compatibility

### DIFF
--- a/dynamic_preferences/migrations/0001_initial.py
+++ b/dynamic_preferences/migrations/0001_initial.py
@@ -33,7 +33,9 @@ class Migration(migrations.Migration):
                 ('section', models.CharField(blank=True, default=None, null=True, max_length=150, db_index=True)),
                 ('name', models.CharField(max_length=150, db_index=True)),
                 ('raw_value', models.TextField(blank=True, null=True)),
-                ('instance', models.ForeignKey(to=settings.AUTH_USER_MODEL, related_name='preferences')),
+                ('instance', models.ForeignKey(to=settings.AUTH_USER_MODEL, 
+                                               on_delete=models.CASCADE, 
+                                               related_name='preferences')),
             ],
             options={
                 'verbose_name_plural': 'user preferences',

--- a/dynamic_preferences/migrations/0002_auto_20150712_0332.py
+++ b/dynamic_preferences/migrations/0002_auto_20150712_0332.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='userpreferencemodel',
             name='instance',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='userpreferencemodel',


### PR DESCRIPTION
In Django 2.0 the on_delete field is required for ForeignKey fields 
https://docs.djangoproject.com/en/2.0/ref/models/fields/