### PR TITLE
Add field and changelist_form to PerInstancePreferenceAdmin

### DIFF
--- a/dynamic_preferences/admin.py
+++ b/dynamic_preferences/admin.py
@@ -74,6 +74,8 @@ admin.site.register(GlobalPreferenceModel, GlobalPreferenceAdmin)
 
 class PerInstancePreferenceAdmin(DynamicPreferenceAdmin):
     list_display = ('instance',) + DynamicPreferenceAdmin.list_display
+    fields = ('instance',) + DynamicPreferenceAdmin.fields
     raw_id_fields = ('instance',)
     form = SinglePerInstancePreferenceForm
+    changelist_form = SinglePerInstancePreferenceForm
     list_select_related = True


### PR DESCRIPTION
Hi again! Two hopefully small changes:

1. I added `instance` to the admin form fields for per-instance preferences. I assume this is what you intended, since `instance` was already in `raw_id_fields`. I haven't put it in `readonly_fields`, though.

2. Currently if you enable the `ADMIN_ENABLE_CHANGELIST_FORM` option, per-instance preference pages crash with an `AttributeError` because `PerInstancePreferenceAdmin.changelist_form` isn't defined. So I added this and made it the same as `PerInstancePreferenceAdmin.form`, following the example of the other admin classes.

Thanks again for everything 🙂 