### PR TITLE
Get proper PreferenceModelsRegistry when preference is proxy model

### DIFF
--- a/dynamic_preferences/registries.py
+++ b/dynamic_preferences/registries.py
@@ -52,7 +52,10 @@ class PreferenceModelsRegistry(persisting_theory.Registry):
         setattr(instance_class, preferences_settings.MANAGER_ATTRIBUTE, getter)
 
     def get_by_preference(self, preference):
-        return self[preference.__class__]
+        return self[
+            preference._meta.proxy_for_model if preference._meta.proxy
+            else preference.__class__
+        ]
 
     def get_by_instance(self, instance):
         """Return a preference registry using a model instance"""


### PR DESCRIPTION
Bugfix for #134.

If `preference` is proxy model (e.g. when you want to have your own admin instead native one), `PreferenceModelsRegistry.register()` sets `self[preference_model]` for proxy model, but `PreferenceModelsRegistry.get_by_preference()` tries to get preference by native model.