### PR TITLE
Update outdated context_processors documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,12 +23,20 @@ Then, create missing tables in your database::
 
     python manage.py migrate dynamic_preferences
 
-Add this to :py:const:`settings.TEMPLATE_CONTEXT_PROCESSORS` if you want to access preferences from templates::
+Add this to :py:const:`settings.TEMPLATES` if you want to access preferences from templates::
 
-    TEMPLATE_CONTEXT_PROCESSORS =  (
-        'django.core.context_processors.request',
-        'dynamic_preferences.processors.global_preferences',
-    )
+    TEMPLATES = [
+        {
+            # ...
+            'OPTIONS': {
+                'context_processors': [
+                    # ...
+                    'django.template.context_processors.request',
+                    'dynamic_preferences.processors.global_preferences',
+                ],
+            },
+        },
+    ]
 
 Settings
 ********


### PR DESCRIPTION
Hello,

The documentation is not up to date with Django 1.11, because ```django.core.context_processors.request``` has moved to ```django.template.context_processors.request```.

See: https://docs.djangoproject.com/en/1.11/releases/1.8/#django-core-context-processors
> django.core.context_processors
> Built-in template context processors have been moved to django.template.context_processors.