### PR TITLE
 Fix ModelChoicePreference when using with model attribute and not queryset

### DIFF
--- a/dynamic_preferences/exceptions.py
+++ b/dynamic_preferences/exceptions.py
@@ -23,3 +23,6 @@ class DoesNotExist(DynamicPreferencesException):
 
 class CachedValueNotFound(DynamicPreferencesException):
     detail_default = 'Cached value not found'
+
+class MissingModel(DynamicPreferencesException):
+    detail_default = 'You must define a model choice through "model" or "queryset" attribute'

--- a/dynamic_preferences/exceptions.py
+++ b/dynamic_preferences/exceptions.py
@@ -24,5 +24,7 @@ class DoesNotExist(DynamicPreferencesException):
 class CachedValueNotFound(DynamicPreferencesException):
     detail_default = 'Cached value not found'
 
+
 class MissingModel(DynamicPreferencesException):
-    detail_default = 'You must define a model choice through "model" or "queryset" attribute'
+    detail_default = 'You must define a model choice through "model" \
+                      or "queryset" attribute'

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -309,10 +309,10 @@ class ModelChoicePreference(BasePreferenceType):
     def __init__(self, *args, **kwargs):
         super(ModelChoicePreference, self).__init__(*args, **kwargs)
 
-        if self.model:
+        if self.model is not None:
             # Set queryset following model attribute
             self.queryset = self.model.objects.all()
-        elif self.queryset:
+        elif self.queryset is not None:
             # Set model following queryset attribute
             self.model = self.queryset.model
         else:

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -308,7 +308,7 @@ class ModelChoicePreference(BasePreferenceType):
 
     def __init__(self, *args, **kwargs):
         super(ModelChoicePreference, self).__init__(*args, **kwargs)
-        
+
         if self.model:
             # Set queryset following model attribute
             self.queryset = self.model.objects.all()

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -9,6 +9,7 @@ from django.db.models.signals import pre_delete
 from django.core.files.storage import default_storage
 
 from .preferences import AbstractPreference, Section
+from .exceptions import MissingModel
 from dynamic_preferences.serializers import *
 from dynamic_preferences.settings import preferences_settings
 
@@ -306,11 +307,16 @@ class ModelChoicePreference(BasePreferenceType):
     signals_handlers = {}
 
     def __init__(self, *args, **kwargs):
-
         super(ModelChoicePreference, self).__init__(*args, **kwargs)
-        self.model = self.model or self.queryset.model
-        if not hasattr(self, 'queryset'):
+        
+        if self.model:
+            # Set queryset following model attribute
             self.queryset = self.model.objects.all()
+        elif self.queryset:
+            # Set model following queryset attribute
+            self.model = self.queryset.model
+        else:
+            raise MissingModel
 
         self.serializer = self.serializer_class(self.model)
 

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -42,6 +42,12 @@ class MaxUsers(IntPreference):
 class NoDefault(IntPreference):
     section = "user"
     name = "no_default"
+    
+    
+class NoModel(ModelChoicePreference):
+    section = "blog"
+    name = "no_model"
+    default = None
 
 
 @global_preferences_registry.register

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -163,6 +163,10 @@ class TestPreferences(BaseTest, TestCase):
         with self.assertRaises(exceptions.MissingDefault):
             preference = prefs.NoDefault()
 
+    def test_modelchoicepreference_requires_model_value(self):
+        with self.assertRaises(exceptions.MissingModel):
+            preference = prefs.NoModel()
+
     def test_get_field_uses_field_kwargs(self):
         class P(StringPreference):
             name = 'test'


### PR DESCRIPTION
Fix ModelChoicePreference when model is set instead of queryset.

Also, I add the MissingModel exception when model and queryset attributes are unset.