### PR TITLE
Handle 'required' attribute for all inherited BasePreferenceType class

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -42,6 +42,7 @@ Let's declare a few preferences in this file:
         section = general
         name = 'title'
         default = 'My site'
+        required = False
 
     @global_preferences_registry.register
     class MaintenanceMode(BooleanPreference):
@@ -264,8 +265,9 @@ Both methods are perfectly valid. You can override the following attributes:
 * ``field_kwargs``: kwargs that are passed to the field class upon instantiation. Ensure to call ``super()`` since some default are provided.
 * ``verbose_name``: used in admin and as a label for the field
 * ``help_text``: used in admin and in the field
-* ``default``: the default value for the preference, taht will also be used as initial data for the form field
+* ``default``: the default value for the preference, that will also be used as initial data for the form field
 * ``widget``: the widget used for the form field
+* ``required``: used to define if the value is required
 
 Accessing global preferences within a template
 ----------------------------------------------

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -92,11 +92,14 @@ class BasePreferenceType(AbstractPreference):
         - :py:attr:`instance.verbose_name` for the field label
         - :py:attr:`instance.help_text` for the field help text
         - :py:attr:`instance.widget` for the field widget
+        - :py:attr:`instance.required` defined if the value is required or not
+        - :py:attr:`instance.initial` defined if the initial value
         """
         kwargs = self.field_kwargs.copy()
         kwargs.setdefault('label', self.get('verbose_name'))
         kwargs.setdefault('help_text', self.get('help_text'))
         kwargs.setdefault('widget', self.get('widget'))
+        kwargs.setdefault('required', self.get('required'))
         kwargs.setdefault('initial', self.initial)
         kwargs.setdefault('validators', [])
         kwargs['validators'].append(self.validate)
@@ -159,11 +162,7 @@ class BooleanPreference(BasePreferenceType):
     """
     field_class = forms.BooleanField
     serializer = BooleanSerializer
-
-    def get_field_kwargs(self):
-        kwargs = super(BooleanPreference, self).get_field_kwargs()
-        kwargs['required'] = False
-        return kwargs
+    required = False
 
 
 class IntegerPreference(BasePreferenceType):

--- a/example/example/dynamic_preferences_registry.py
+++ b/example/example/dynamic_preferences_registry.py
@@ -2,6 +2,9 @@ from dynamic_preferences.types import *
 from dynamic_preferences.registries import global_preferences_registry
 from dynamic_preferences.users.registries import user_preferences_registry
 
+from .models import MyModel
+
+_section = Section("section")
 
 @global_preferences_registry.register
 class RegistrationAllowed(BooleanPreference):
@@ -80,3 +83,12 @@ class IsFanOfTokioHotel(BooleanPreference):
     section = "music"
     name = "is_fan_of_tokio_hotel"
     default = False
+
+@user_preferences_registry.register
+class MyModelPreference(ModelChoicePreference):
+
+    section = _section
+    name = "MyModel_preference"
+    default = None
+    queryset = MyModel.objects.all()
+    required = False


### PR DESCRIPTION
Handle 'required' attribute for all BasePreferenceType subclass in addition to field_kwargs way.

For example :

class MyPreference(StringPreference):
     field_kwargs = {
                'required': False
            }

equals to :

class MyPreference(StringPreference):
     required = False