### PR TITLE
Fix string format arguments in get_by_name error

### DIFF
--- a/dynamic_preferences/registries.py
+++ b/dynamic_preferences/registries.py
@@ -181,7 +181,7 @@ class PreferenceRegistry(persisting_theory.Registry):
                 if preference.name == name:
                     return preference
         raise NotFoundInRegistry("No such preference in {0} with name={1}".format(
-            name))
+            self.__class__.__name__, name))
 
     def manager(self, **kwargs):
         """Return a preference manager that can be used to retrieve preference values"""


### PR DESCRIPTION
Nothing major, just that it currently throws "tuple index out of range" here rather than raising the actual error, so this change fixes the error message.