### PR TITLE
Fixed direct access to ChoicePreference.choice

### DIFF
--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -230,7 +230,7 @@ class ChoicePreference(BasePreferenceType):
 
     def get_field_kwargs(self):
         field_kwargs = super(ChoicePreference, self).get_field_kwargs()
-        field_kwargs['choices'] = self.choices or self.field_attribute['initial']
+        field_kwargs['choices'] = self.get('choices') or self.field_attribute['initial']
         return field_kwargs
 
     def get_api_additional_data(self):


### PR DESCRIPTION
Use `ChoicePreference.get('choice')` instead of direct access to property in order to be able to use a `get_choices() `method.