### PR TITLE
fix(migrations): add missing `verbose_name`

### DIFF
--- a/dynamic_preferences/migrations/0003_auto_20151223_1407.py
+++ b/dynamic_preferences/migrations/0003_auto_20151223_1407.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='globalpreferencemodel',
             name='section',
-            field=models.CharField(max_length=150, null=True, default=None, db_index=True, blank=True),
+            field=models.CharField(max_length=150, null=True, default=None, db_index=True, blank=True, verbose_name='Section Name'),
             preserve_default=True,
         ),
     ]


### PR DESCRIPTION
Every time I run `migrate` when deploying I get

>   Your models have changes that are not yet reflected in a migration, and so won't be applied.
>  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.

This is due to the `verbose_name` that was added to `BasePreferenceModel.section` field without running `makemigrations`.
  
We can obviously create a new migration, but in such cases, a change of `verbose_name` or `help_text`, I prefer editing the last migration of the affected field.