### PR TITLE
Add time preference type

### DIFF
--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -2,11 +2,11 @@ from __future__ import unicode_literals
 import decimal
 import os
 
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta, datetime, time
 
 from django.conf import settings
 from django.core.validators import EMPTY_VALUES
-from django.utils.dateparse import parse_duration, parse_datetime, parse_date
+from django.utils.dateparse import parse_duration, parse_datetime, parse_date, parse_time
 from django.utils.duration import duration_string
 from django.utils.encoding import force_text
 from django.utils.timezone import utc, is_aware, make_aware, make_naive, get_default_timezone
@@ -389,4 +389,21 @@ class DateTimeSerializer(BaseSerializer):
         parsed = parse_datetime(force_text(value))
         if parsed is None:
             raise cls.exception("Value {0} cannot be converted to a datetime object".format(value))
+        return parsed
+
+
+class TimeSerializer(BaseSerializer):
+    @classmethod
+    def to_db(cls, value, **kwargs):
+        if not isinstance(value, time):
+            raise cls.exception("Cannot serialize, value {0} is not a time object".format(value))
+
+        return value.isoformat()
+
+    @classmethod
+    def to_python(cls, value, **kwargs):
+        parsed = parse_time(force_text(value))
+        if parsed is None:
+            raise cls.exception("Value {0} cannot be converted to a time object".format(value))
+
         return parsed

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -461,3 +461,14 @@ class DateTimePreference(BasePreferenceType):
 
     def api_repr(self, value):
         return value.isoformat()
+
+
+class TimePreference(BasePreferenceType):
+    """
+    A preference type that stores a time.
+    """
+    field_class = forms.TimeField
+    serializer = TimeSerializer
+
+    def api_repr(self, value):
+        return value.isoformat()

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -192,3 +192,10 @@ class BirthDateTime(DateTimePreference):
     section = Section('child', verbose_name='Child Section Verbose Name')
     name = 'BirthDateTime'
     default = datetime(1992, 5, 4, 3, 4, 10, 150, FixedOffset(offset=330))
+
+
+@global_preferences_registry.register
+class OpenningTime(TimePreference):
+    section = 'company'
+    name = 'OpenningTime'
+    default = time(hour=8, minute=0)

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from decimal import Decimal
 
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta, datetime, time
 from django.test import LiveServerTestCase, TestCase
 from django.urls import reverse
 from django.core.management import call_command
@@ -50,6 +50,7 @@ class TestGlobalPreferences(BaseTest, TestCase):
             u'blog__logo2': None,
             u'company__RegistrationDate': date(1998, 9, 4),
             u'child__BirthDateTime': datetime(1992, 5, 4, 3, 4, 10, 150, tzinfo=FixedOffset(offset=330)),
+            u'company__OpenningTime': time(hour=8, minute=0),
             u'user__registration_allowed': False}
         self.assertDictEqual(manager.all(), expected)
 
@@ -106,7 +107,7 @@ class TestViews(BaseTest, LiveServerTestCase):
         url = reverse("dynamic_preferences:global")
         self.client.login(username='admin', password="test")
         response = self.client.get(url)
-        self.assertEqual(len(response.context['form'].fields), 14)
+        self.assertEqual(len(response.context['form'].fields), 15)
         self.assertEqual(
             response.context['registry'], registry)
 
@@ -161,6 +162,7 @@ class TestViews(BaseTest, LiveServerTestCase):
             'child__BirthDateTime': datetime.now(),
             'type__cost': 1,
             'exam__duration': timedelta(hours=5),
+            'company__OpenningTime': time(hour=8, minute=0),
         }
         response = self.client.post(url, data)
         for key, expected_value in data.items():

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta, datetime, time
 from django.test import TestCase, override_settings
 from django.template import defaultfilters
 from django.utils.timezone import FixedOffset
@@ -192,6 +192,25 @@ class TestSerializers(TestCase):
         with self.assertRaises(s.exception) as ex:
             s.deserialize('abcd')
             self.assertEqual(ex.exception.args, ('Value abcd cannot be converted to a datetime object',))
+
+
+    def test_time_serialization(self):
+        s = serializers.TimeSerializer
+
+        self.assertEqual(s.serialize(time(hour=5)), '05:00:00')
+        self.assertEqual(s.serialize(time(minute=30)), '00:30:00')
+        self.assertEqual(s.serialize(time(23, 59, 59, 999999)), '23:59:59.999999')
+
+        with self.assertRaises(s.exception):
+            s.serialize('Not a time')
+
+    def test_time_deserialization(self):
+        s = serializers.TimeSerializer
+
+        self.assertEqual(s.deserialize('23:00:00'), time(hour=23))
+
+        with self.assertRaises(s.exception):
+            s.deserialize('Invalid time string')
 
 
 class TestModelSerializers(TestCase):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 import os
 import decimal
 
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta, datetime, time
 from django import forms
 from django.test import TestCase
 from django.db.models import signals
@@ -135,6 +135,15 @@ class TestTypes(BaseTest, TestCase):
         preference = P()
 
         self.assertEqual(preference.field.initial, initial_date_time)
+
+    @override_settings(DYNAMIC_PREFERENCES={'VALIDATE_NAMES': False})
+    def test_time_preference(self):
+        class P(types.TimePreference):
+            default = time(0)
+
+        preference = P()
+
+        self.assertEqual(preference.field.initial, time(0))
 
 
 class TestFilePreference(BaseTest, TestCase):


### PR DESCRIPTION
Closes #186 

As I said on #186, recently I've needed a Time preference and created a time preference type in my project.

I wanted to make a PR to add it to this project, because these changes did worked on my django project, but I couldn't properly install the dev environment and run the tests locally, even following the contributing guide. I faced many issues with python versions, since I'm new to python, and I couldn't solve them.

I've follow what @rvignesh89 did on #100. I hope this PR contribute with the project and let me know if I can improve anything.

Thanks.
