### PR TITLE
docs: Fix simple typo, timdelta -> timedelta

### DIFF
--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -432,7 +432,7 @@ class FilePreference(BasePreferenceType):
 
 class DurationPreference(BasePreferenceType):
     """
-    A preference type that stores a timdelta.
+    A preference type that stores a timedelta.
     """
     field_class = forms.DurationField
     serializer = DurationSerializer


### PR DESCRIPTION
There is a small typo in dynamic_preferences/types.py.

Should read `timedelta` rather than `timdelta`.

