### PR TITLE
Pass instance provided in form builder to manager

### DIFF
--- a/dynamic_preferences/forms.py
+++ b/dynamic_preferences/forms.py
@@ -100,8 +100,8 @@ def preference_form_builder(form_base_class, preferences=[], **kwargs):
 
     fields = OrderedDict()
     instances = []
-    model_kwargs = kwargs.get('model', {})
-    manager = registry.manager(**model_kwargs)
+    manager_kwargs = {"instance": kwargs.get("instance", None)}
+    manager = registry.manager(**manager_kwargs)
 
     for preference in preferences_obj:
         f = preference.field


### PR DESCRIPTION
In `preference_form_builder` there was passed an keyword argument called `model`, if set, to the registry's method `manager`. In the method the provided kwargs are passed directly to `PreferencesManager`, but there is already an argument `model` provided directly:

```
return PreferencesManager(registry=self, model=self.preference_model, **kwargs)
```

The only sensible argument that can passed is `instance`.