### PR TITLE
Add MultipleChoicePreference

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+1.10 (2020-xx-xx)
+****************
+
+- Add MultipleChoicePreference
+
+Contributors:
+
+- @Natureshadow
 
 1.9 (2020-05-06)
 ****************

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -419,17 +419,27 @@ class MultipleSerializer(BaseSerializer):
         if not value:
             return
 
-        value = list(value)
+        # This makes the use of the separator in choices safe by duplicating
+        # it in each value before they are joined later on
+        # Contract: choices keys cannot be empty
+        value = [str(v).replace(cls.separator, cls.separator*2) for v in value]
+        if '' in value:
+            raise cls.exception('Choices must not be empty')
 
         if cls.sort:
             value = sorted(value)
 
-        return cls.separator.join(map(str, value))
+        return cls.separator.join(value)
 
     @classmethod
     def to_python(cls, value, **kwargs):
         if value in EMPTY_VALUES:
             return []
 
-        values = value.split(cls.separator)
-        return list(map(str, values))
+        ret = value.split(cls.separator)
+        # Duplication of separator is reverted (cf. to_db)
+        while '' in ret:
+            pos = ret.index('')
+            val = ret[pos-1] + cls.separator + ret[pos+1]
+            ret = ret[0:pos-1] + [val] + ret[pos+2:]
+        return ret

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -410,26 +410,26 @@ class TimeSerializer(BaseSerializer):
         return parsed
 
 
-class MultipleSerializer(StringSerializer):
+class MultipleSerializer(BaseSerializer):
     separator = ","
     sort = True
 
     @classmethod
-    def to_db(self, value, **kwargs):
+    def to_db(cls, value, **kwargs):
         if not value:
             return
 
         value = list(value)
 
-        if self.sort:
+        if cls.sort:
             value = sorted(value)
 
-        return self.separator.join(map(StringSerializer.to_db, value))
+        return cls.separator.join(map(str, value))
 
     @classmethod
-    def to_python(self, value, **kwargs):
+    def to_python(cls, value, **kwargs):
         if value in EMPTY_VALUES:
-            return ''
+            return []
 
-        values = value.split(",")
-        return list(map(StringSerializer.to_python, values))
+        values = value.split(cls.separator)
+        return list(map(str, values))

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -410,7 +410,7 @@ class TimeSerializer(BaseSerializer):
         return parsed
 
 
-class ChoiceMultipleSerializer(StringSerializer):
+class MultipleSerializer(StringSerializer):
     separator = ","
     sort = True
 

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -408,3 +408,28 @@ class TimeSerializer(BaseSerializer):
             raise cls.exception("Value {0} cannot be converted to a time object".format(value))
 
         return parsed
+
+
+class ChoiceMultipleSerializer(StringSerializer):
+    separator = ","
+    sort = True
+
+    @classmethod
+    def to_db(self, value, **kwargs):
+        if not value:
+            return
+
+        value = list(value)
+
+        if self.sort:
+            value = sorted(value)
+
+        return self.separator.join(map(StringSerializer.to_db, value))
+
+    @classmethod
+    def to_python(self, value, **kwargs):
+        if value in EMPTY_VALUES:
+            return ''
+
+        values = value.split(",")
+        return list(map(StringSerializer.to_python, values))

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -451,7 +451,7 @@ class DatePreference(BasePreferenceType):
     def api_repr(self, value):
         return value.isoformat()
 
-    
+
 class DateTimePreference(BasePreferenceType):
     """
         A preference type that stores a datetime.
@@ -472,3 +472,13 @@ class TimePreference(BasePreferenceType):
 
     def api_repr(self, value):
         return value.isoformat()
+
+
+class ChoiceMultiplePreference(ChoicePreference):
+    widget = forms.CheckboxSelectMultiple
+    field_class = forms.MultipleChoiceField
+    serializer = ChoiceMultipleSerializer
+
+    def validate(self, value):
+        for v in value:
+            super().validate(v)

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -475,6 +475,29 @@ class TimePreference(BasePreferenceType):
 
 
 class MultipleChoicePreference(ChoicePreference):
+    """
+    A preference type that stores multiple strings among a list of choices.
+
+    :Example:
+
+    .. code-block:: python
+
+        @registry.register
+        class FeaturedEntries(MultipleChoicePreference):
+            section = Section('blog')
+            name = 'featured_entries'
+            choices = [
+                ('c', 'Carrot'),
+                ('t', 'Tomato'),
+            ]
+
+    .. note::
+
+       Internally, the selected choices are stored as a string, separated by a
+       separator. The separator defaults to ','. The way this is implemented still
+       is sae also on keys that cotain the separator, but if in doubt, you can still
+       set the :py:attr:`separator` to any other character.
+    """
     widget = forms.CheckboxSelectMultiple
     field_class = forms.MultipleChoiceField
     serializer = MultipleSerializer

--- a/dynamic_preferences/types.py
+++ b/dynamic_preferences/types.py
@@ -474,10 +474,10 @@ class TimePreference(BasePreferenceType):
         return value.isoformat()
 
 
-class ChoiceMultiplePreference(ChoicePreference):
+class MultipleChoicePreference(ChoicePreference):
     widget = forms.CheckboxSelectMultiple
     field_class = forms.MultipleChoiceField
-    serializer = ChoiceMultipleSerializer
+    serializer = MultipleSerializer
 
     def validate(self, value):
         for v in value:

--- a/example/example/dynamic_preferences_registry.py
+++ b/example/example/dynamic_preferences_registry.py
@@ -57,6 +57,18 @@ class FavoriteVegetable(ChoicePreference):
     default = "C"
 
 
+@global_preferences_registry.register
+class AdminUsers(ChoiceMultiplePreference):
+    name = 'admin_users'
+    section = 'auth'
+    default = None
+    choices = (
+        ("0", "Serge"),
+        ("1", "Alina"),
+        ("2", "Anand")
+    )
+
+
 @user_preferences_registry.register
 class FavouriteColour(StringPreference):
     """

--- a/example/example/dynamic_preferences_registry.py
+++ b/example/example/dynamic_preferences_registry.py
@@ -58,7 +58,7 @@ class FavoriteVegetable(ChoicePreference):
 
 
 @global_preferences_registry.register
-class AdminUsers(ChoiceMultiplePreference):
+class AdminUsers(MultipleChoicePreference):
     name = 'admin_users'
     section = 'auth'
     default = None

--- a/tests/test_app/dynamic_preferences_registry.py
+++ b/tests/test_app/dynamic_preferences_registry.py
@@ -99,6 +99,18 @@ class FavoriteVegetable(ChoicePreference):
 
 
 @user_preferences_registry.register
+class FavoriteVegetables(MultipleChoicePreference):
+    choices = (
+        ("C", "Carrot"),
+        ("T", "Tomato. I know, it's not a vegetable"),
+        ("P", "Potato")
+    )
+    section = "user"
+    name = "favorite_vegetables"
+    default = ["C", "P"]
+
+
+@user_preferences_registry.register
 class FavouriteColour(StringPreference):
     """
     What's your favourite colour ?

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -212,6 +212,23 @@ class TestSerializers(TestCase):
         with self.assertRaises(s.exception):
             s.deserialize('Invalid time string')
 
+    def test_multiple_serialization(self):
+        s = serializers.MultipleSerializer
+
+        self.assertEqual(s.serialize(['a', 'b', 'c']), 'a,b,c')
+        self.assertEqual(s.serialize(['key,with,comma', 'b', 'another,key,with,comma']),
+            'another,,key,,with,,comma,b,key,,with,,comma')
+
+        with self.assertRaises(s.exception):
+            s.serialize(['a', '', 'c'])
+
+    def test_multiple_deserialization(self):
+        s = serializers.MultipleSerializer
+
+        self.assertEqual(s.deserialize('a,b,c'), ['a', 'b', 'c'])
+        self.assertEqual(s.deserialize('key,,with,,comma,b,another,,key,,with,,comma'),
+            ['key,with,comma', 'b', 'another,key,with,comma'])
+
 
 class TestModelSerializers(TestCase):
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -260,6 +260,17 @@ class TestChoicePreference(BaseTest, TestCase):
         with self.assertRaises(forms.ValidationError):
             self.user.preferences['user__favorite_vegetable'] = 'Nope'
 
+    def test_multiple_choice_preference(self):
+        self.user.preferences['user__favorite_vegetables'] = ['C', 'T']
+        self.assertEqual(
+            self.user.preferences['user__favorite_vegetables'], ['C', 'T'])
+        self.user.preferences['user__favorite_vegetables'] = ['P']
+        self.assertEqual(
+            self.user.preferences['user__favorite_vegetables'], ['P'])
+
+        with self.assertRaises(forms.ValidationError):
+            self.user.preferences['user__favorite_vegetables'] = ['Nope', 'C']
+
 
 class TestModelChoicePreference(BaseTest, TestCase):
 

--- a/tests/test_user_preferences.py
+++ b/tests/test_user_preferences.py
@@ -80,6 +80,7 @@ class TestDynamicPreferences(BaseTest, TestCase):
             u'misc__favourite_colour': u'Green',
             u'misc__is_zombie': True,
             u'user__favorite_vegetable': 'C',
+            u'user__favorite_vegetables': ['C', 'P'],
             u'test__SUserStringPref': u'Hello world!',
             u'test__SiteBooleanPref': False,
             u'test__TestUserPref1': u'default value',
@@ -201,7 +202,7 @@ class TestViewSets(BaseTest, TestCase):
         payload = json.loads(response.content.decode('utf-8'))
 
         # This should be 7 because each user gets 7 preferences by default.
-        self.assertEqual(len(payload), 7)
+        self.assertEqual(len(payload), 8)
 
         for e in payload:
             pref = manager.get_db_pref(section=e['section'], name=e['name'])


### PR DESCRIPTION
This implements a `MultipleChoicePreference`, along the lines of the MultipleChoiceField in Django.

It is based on the previous work in #165 and updates it to current develop branch, adds some fixes (including support for choices containing the separator), and tests.